### PR TITLE
Refactor main API

### DIFF
--- a/src/rapids_pre_commit_hooks/shell/__init__.py
+++ b/src/rapids_pre_commit_hooks/shell/__init__.py
@@ -14,7 +14,7 @@
 
 import bashlex
 
-from ..lint import LintMain
+from ..lint import ExecutionContext, LintMain
 
 
 class LintVisitor(bashlex.ast.nodevisitor):
@@ -26,9 +26,9 @@ class LintVisitor(bashlex.ast.nodevisitor):
         return self.linter.add_warning(pos, msg)
 
 
-class ShellMain(LintMain):
-    def __init__(self):
-        super().__init__()
+class ShellExecutionContext(ExecutionContext):
+    def __init__(self, args):
+        super().__init__(args)
         self.visitors = []
         self.add_check(self.check_shell)
 
@@ -42,3 +42,7 @@ class ShellMain(LintMain):
             visitor = cls(linter, args)
             for part in parts:
                 visitor.visit(part)
+
+
+class ShellMain(LintMain):
+    context_class = ShellExecutionContext

--- a/src/rapids_pre_commit_hooks/shell/verify_conda_yes.py
+++ b/src/rapids_pre_commit_hooks/shell/verify_conda_yes.py
@@ -74,8 +74,9 @@ class VerifyCondaYesVisitor(LintVisitor):
 
 
 def main():
-    with ShellMain() as m:
-        m.add_visitor_class(VerifyCondaYesVisitor)
+    m = ShellMain()
+    with m.execute() as ctx:
+        ctx.add_visitor_class(VerifyCondaYesVisitor)
 
 
 if __name__ == "__main__":

--- a/test/rapids_pre_commit_hooks/test_lint.py
+++ b/test/rapids_pre_commit_hooks/test_lint.py
@@ -152,16 +152,20 @@ class TestLintMain:
 
     def test_no_warnings_no_fix(self, hello_world_file, capsys):
         with MockArgv("check-test", "--check-test", hello_world_file.name):
-            with LintMain() as m:
-                m.argparser.add_argument("--check-test", action="store_true")
+            m = LintMain()
+            m.argparser.add_argument("--check-test", action="store_true")
+            with m.execute():
+                pass
         assert hello_world_file.read() == "Hello world!"
         captured = capsys.readouterr()
         assert captured.out == ""
 
     def test_no_warnings_fix(self, hello_world_file, capsys):
         with MockArgv("check-test", "--check-test", "--fix", hello_world_file.name):
-            with LintMain() as m:
-                m.argparser.add_argument("--check-test", action="store_true")
+            m = LintMain()
+            m.argparser.add_argument("--check-test", action="store_true")
+            with m.execute():
+                pass
         assert hello_world_file.read() == "Hello world!"
         captured = capsys.readouterr()
         assert captured.out == ""
@@ -170,9 +174,10 @@ class TestLintMain:
         with MockArgv(
             "check-test", "--check-test", hello_world_file.name
         ), pytest.raises(SystemExit, match=r"^1$"):
-            with LintMain() as m:
-                m.argparser.add_argument("--check-test", action="store_true")
-                m.add_check(self.the_check)
+            m = LintMain()
+            m.argparser.add_argument("--check-test", action="store_true")
+            with m.execute() as ctx:
+                ctx.add_check(self.the_check)
         assert hello_world_file.read() == "Hello world!"
         captured = capsys.readouterr()
         assert (
@@ -204,9 +209,10 @@ note: suggested fix
         with MockArgv(
             "check-test", "--check-test", "--fix", hello_world_file.name
         ), pytest.raises(SystemExit, match=r"^1$"):
-            with LintMain() as m:
-                m.argparser.add_argument("--check-test", action="store_true")
-                m.add_check(self.the_check)
+            m = LintMain()
+            m.argparser.add_argument("--check-test", action="store_true")
+            with m.execute() as ctx:
+                ctx.add_check(self.the_check)
         assert hello_world_file.read() == "Good bye, world!"
         captured = capsys.readouterr()
         assert (
@@ -242,9 +248,10 @@ note: suggested fix applied
             hello_world_file.name,
             hello_file.name,
         ), pytest.raises(SystemExit, match=r"^1$"):
-            with LintMain() as m:
-                m.argparser.add_argument("--check-test", action="store_true")
-                m.add_check(self.the_check)
+            m = LintMain()
+            m.argparser.add_argument("--check-test", action="store_true")
+            with m.execute() as ctx:
+                ctx.add_check(self.the_check)
         assert hello_world_file.read() == "Good bye, world!"
         assert hello_file.read() == "Good bye!"
         captured = capsys.readouterr()


### PR DESCRIPTION
Separate argument creation from execution. This will allow us to access the list of files before any checks are run on them.