### PR TITLE
Update pre-commit-hooks to v0.0.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         args:
         - --show-source
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.0.2
+    rev: v0.0.3
     hooks:
       - id: verify-copyright
         files: |


### PR DESCRIPTION
This fixes an issue with how the `verify-copyright` hook handles multiple merge bases.
