### PR TITLE
Skip checking invalid requirements

### DIFF
--- a/src/rapids_pre_commit_hooks/alpha_spec.py
+++ b/src/rapids_pre_commit_hooks/alpha_spec.py
@@ -16,7 +16,7 @@ import re
 from functools import total_ordering
 
 import yaml
-from packaging.requirements import Requirement
+from packaging.requirements import InvalidRequirement, Requirement
 
 from .lint import LintMain
 
@@ -104,7 +104,10 @@ def check_package_spec(linter, args, node):
         return ",".join(sorted(specifiers, key=SpecPriority))
 
     if node_has_type(node, "str"):
-        req = Requirement(node.value)
+        try:
+            req = Requirement(node.value)
+        except InvalidRequirement:
+            return
         if req.name in RAPIDS_ALPHA_SPEC_PACKAGES or is_rapids_cuda_suffixed_package(
             req.name
         ):

--- a/test/rapids_pre_commit_hooks/test_alpha_spec.py
+++ b/test/rapids_pre_commit_hooks/test_alpha_spec.py
@@ -94,6 +94,10 @@ def test_is_rapids_cuda_suffixed_package(name, is_suffixed):
             "cuml>=24.04,<24.06",
         ),
         ("packaging", "packaging", "development", None),
+        (None, "--extra-index-url=https://pypi.nvidia.com", "development", None),
+        (None, "--extra-index-url=https://pypi.nvidia.com", "release", None),
+        (None, "gcc_linux-64=11.*", "development", None),
+        (None, "gcc_linux-64=11.*", "release", None),
     ],
 )
 def test_check_package_spec(package, content, mode, replacement):


### PR DESCRIPTION
Conda and requirements.txt allow some requirements that are not valid in a pyproject.toml. Skip over these when doing the check.