### PR TITLE
Account for aliases in alpha spec check

### DIFF
--- a/src/rapids_pre_commit_hooks/alpha_spec.py
+++ b/src/rapids_pre_commit_hooks/alpha_spec.py
@@ -246,7 +246,7 @@ class AnchorPreservingLoader(yaml.SafeLoader):
 
 
 def check_alpha_spec(linter, args):
-    loader = yaml.SafeLoader(linter.content)
+    loader = AnchorPreservingLoader(linter.content)
     try:
         root = loader.get_single_node()
     finally:

--- a/src/rapids_pre_commit_hooks/alpha_spec.py
+++ b/src/rapids_pre_commit_hooks/alpha_spec.py
@@ -79,7 +79,7 @@ def is_rapids_cuda_suffixed_package(name):
     )
 
 
-def check_package_spec(linter, args, node):
+def check_package_spec(linter, args, anchors, used_anchors, node):
     @total_ordering
     class SpecPriority:
         def __init__(self, spec):
@@ -111,42 +111,51 @@ def check_package_spec(linter, args, node):
         if req.name in RAPIDS_ALPHA_SPEC_PACKAGES or is_rapids_cuda_suffixed_package(
             req.name
         ):
-            has_alpha_spec = any(str(s) == ALPHA_SPECIFIER for s in req.specifier)
-            if args.mode == "development" and not has_alpha_spec:
-                linter.add_warning(
-                    (node.start_mark.index, node.end_mark.index),
-                    f"add alpha spec for RAPIDS package {req.name}",
-                ).add_replacement(
-                    (node.start_mark.index, node.end_mark.index),
-                    str(
-                        req.name
-                        + create_specifier_string(
-                            {str(s) for s in req.specifier} | {ALPHA_SPECIFIER}
-                        )
-                    ),
-                )
-            elif args.mode == "release" and has_alpha_spec:
-                linter.add_warning(
-                    (node.start_mark.index, node.end_mark.index),
-                    f"remove alpha spec for RAPIDS package {req.name}",
-                ).add_replacement(
-                    (node.start_mark.index, node.end_mark.index),
-                    str(
-                        req.name
-                        + create_specifier_string(
-                            {str(s) for s in req.specifier} - {ALPHA_SPECIFIER}
-                        )
-                    ),
-                )
+            anchor = (
+                keys[0]
+                if (keys := [key for key, value in anchors.items() if value == node])
+                else None
+            )
+            if anchor not in used_anchors:
+                used_anchors.add(anchor)
+                has_alpha_spec = any(str(s) == ALPHA_SPECIFIER for s in req.specifier)
+                if args.mode == "development" and not has_alpha_spec:
+                    linter.add_warning(
+                        (node.start_mark.index, node.end_mark.index),
+                        f"add alpha spec for RAPIDS package {req.name}",
+                    ).add_replacement(
+                        (node.start_mark.index, node.end_mark.index),
+                        str(
+                            (f"&{anchor} " if anchor else "")
+                            + req.name
+                            + create_specifier_string(
+                                {str(s) for s in req.specifier} | {ALPHA_SPECIFIER},
+                            )
+                        ),
+                    )
+                elif args.mode == "release" and has_alpha_spec:
+                    linter.add_warning(
+                        (node.start_mark.index, node.end_mark.index),
+                        f"remove alpha spec for RAPIDS package {req.name}",
+                    ).add_replacement(
+                        (node.start_mark.index, node.end_mark.index),
+                        str(
+                            (f"&{anchor} " if anchor else "")
+                            + req.name
+                            + create_specifier_string(
+                                {str(s) for s in req.specifier} - {ALPHA_SPECIFIER},
+                            )
+                        ),
+                    )
 
 
-def check_packages(linter, args, node):
+def check_packages(linter, args, anchors, used_anchors, node):
     if node_has_type(node, "seq"):
         for package_spec in node.value:
-            check_package_spec(linter, args, package_spec)
+            check_package_spec(linter, args, anchors, used_anchors, package_spec)
 
 
-def check_common(linter, args, node):
+def check_common(linter, args, anchors, used_anchors, node):
     if node_has_type(node, "seq"):
         for dependency_set in node.value:
             if node_has_type(dependency_set, "map"):
@@ -155,10 +164,12 @@ def check_common(linter, args, node):
                         node_has_type(dependency_set_key, "str")
                         and dependency_set_key.value == "packages"
                     ):
-                        check_packages(linter, args, dependency_set_value)
+                        check_packages(
+                            linter, args, anchors, used_anchors, dependency_set_value
+                        )
 
 
-def check_matrices(linter, args, node):
+def check_matrices(linter, args, anchors, used_anchors, node):
     if node_has_type(node, "seq"):
         for item in node.value:
             if node_has_type(item, "map"):
@@ -167,10 +178,12 @@ def check_matrices(linter, args, node):
                         node_has_type(matrix_key, "str")
                         and matrix_key.value == "packages"
                     ):
-                        check_packages(linter, args, matrix_value)
+                        check_packages(
+                            linter, args, anchors, used_anchors, matrix_value
+                        )
 
 
-def check_specific(linter, args, node):
+def check_specific(linter, args, anchors, used_anchors, node):
     if node_has_type(node, "seq"):
         for matrix_matcher in node.value:
             if node_has_type(matrix_matcher, "map"):
@@ -179,30 +192,66 @@ def check_specific(linter, args, node):
                         node_has_type(matrix_matcher_key, "str")
                         and matrix_matcher_key.value == "matrices"
                     ):
-                        check_matrices(linter, args, matrix_matcher_value)
+                        check_matrices(
+                            linter, args, anchors, used_anchors, matrix_matcher_value
+                        )
 
 
-def check_dependencies(linter, args, node):
+def check_dependencies(linter, args, anchors, used_anchors, node):
     if node_has_type(node, "map"):
         for _, dependencies_value in node.value:
             if node_has_type(dependencies_value, "map"):
                 for dependency_key, dependency_value in dependencies_value.value:
                     if node_has_type(dependency_key, "str"):
                         if dependency_key.value == "common":
-                            check_common(linter, args, dependency_value)
+                            check_common(
+                                linter, args, anchors, used_anchors, dependency_value
+                            )
                         elif dependency_key.value == "specific":
-                            check_specific(linter, args, dependency_value)
+                            check_specific(
+                                linter, args, anchors, used_anchors, dependency_value
+                            )
 
 
-def check_root(linter, args, node):
+def check_root(linter, args, anchors, used_anchors, node):
     if node_has_type(node, "map"):
         for root_key, root_value in node.value:
             if node_has_type(root_key, "str") and root_key.value == "dependencies":
-                check_dependencies(linter, args, root_value)
+                check_dependencies(linter, args, anchors, used_anchors, root_value)
+
+
+class AnchorPreservingLoader(yaml.SafeLoader):
+    """A SafeLoader that preserves the anchors for later reference. The anchors can
+    be found in the document_anchors member, which is a list of dictionaries, one
+    dictionary for each parsed document.
+    """
+
+    def __init__(self, stream):
+        super().__init__(stream)
+        self.document_anchors = []
+
+    def compose_document(self):
+        # Drop the DOCUMENT-START event.
+        self.get_event()
+
+        # Compose the root node.
+        node = self.compose_node(None, None)
+
+        # Drop the DOCUMENT-END event.
+        self.get_event()
+
+        self.document_anchors.append(self.anchors)
+        self.anchors = {}
+        return node
 
 
 def check_alpha_spec(linter, args):
-    check_root(linter, args, yaml.compose(linter.content))
+    loader = yaml.SafeLoader(linter.content)
+    try:
+        root = loader.get_single_node()
+    finally:
+        loader.dispose()
+    check_root(linter, args, loader.document_anchors[0], set(), root)
 
 
 def main():

--- a/src/rapids_pre_commit_hooks/alpha_spec.py
+++ b/src/rapids_pre_commit_hooks/alpha_spec.py
@@ -117,7 +117,8 @@ def check_package_spec(linter, args, anchors, used_anchors, node):
                 else None
             )
             if anchor not in used_anchors:
-                used_anchors.add(anchor)
+                if anchor is not None:
+                    used_anchors.add(anchor)
                 has_alpha_spec = any(str(s) == ALPHA_SPECIFIER for s in req.specifier)
                 if args.mode == "development" and not has_alpha_spec:
                     linter.add_warning(

--- a/src/rapids_pre_commit_hooks/alpha_spec.py
+++ b/src/rapids_pre_commit_hooks/alpha_spec.py
@@ -111,11 +111,12 @@ def check_package_spec(linter, args, anchors, used_anchors, node):
         if req.name in RAPIDS_ALPHA_SPEC_PACKAGES or is_rapids_cuda_suffixed_package(
             req.name
         ):
-            anchor = (
-                keys[0]
-                if (keys := [key for key, value in anchors.items() if value == node])
-                else None
-            )
+            for key, value in anchors.items():
+                if value == node:
+                    anchor = key
+                    break
+            else:
+                anchor = None
             if anchor not in used_anchors:
                 if anchor is not None:
                     used_anchors.add(anchor)

--- a/test/rapids_pre_commit_hooks/test_alpha_spec.py
+++ b/test/rapids_pre_commit_hooks/test_alpha_spec.py
@@ -139,6 +139,8 @@ def test_check_package_spec_anchor():
         """\
         - &cudf cudf>=24.04,<24.06
         - *cudf
+        - cuml>=24.04,<24.06
+        - rmm>=24.04,<24.06
         """
     )
     args = Mock(mode="development")
@@ -160,8 +162,27 @@ def test_check_package_spec_anchor():
     )
     assert linter.warnings == expected_linter.warnings
     assert used_anchors == {"cudf"}
+
     alpha_spec.check_package_spec(
         linter, args, loader.document_anchors[0], used_anchors, composed.value[1]
+    )
+    assert linter.warnings == expected_linter.warnings
+    assert used_anchors == {"cudf"}
+
+    expected_linter.add_warning(
+        (37, 55), "add alpha spec for RAPIDS package cuml"
+    ).add_replacement((37, 55), "cuml>=24.04,<24.06,>=0.0.0a0")
+    alpha_spec.check_package_spec(
+        linter, args, loader.document_anchors[0], used_anchors, composed.value[2]
+    )
+    assert linter.warnings == expected_linter.warnings
+    assert used_anchors == {"cudf"}
+
+    expected_linter.add_warning(
+        (58, 75), "add alpha spec for RAPIDS package rmm"
+    ).add_replacement((58, 75), "rmm>=24.04,<24.06,>=0.0.0a0")
+    alpha_spec.check_package_spec(
+        linter, args, loader.document_anchors[0], used_anchors, composed.value[3]
     )
     assert linter.warnings == expected_linter.warnings
     assert used_anchors == {"cudf"}

--- a/test/rapids_pre_commit_hooks/test_alpha_spec.py
+++ b/test/rapids_pre_commit_hooks/test_alpha_spec.py
@@ -425,3 +425,31 @@ def test_check_alpha_spec():
         set(),
         mock_anchor_preserving_loader().get_single_node(),
     )
+
+
+def test_check_alpha_spec_integration():
+    CONTENT = dedent(
+        """\
+        dependencies:
+          test:
+            common:
+              - output_types: pyproject
+                packages:
+                  - cudf>=24.04,<24.06
+        """
+    )
+    REPLACED = "cudf>=24.04,<24.06"
+
+    args = Mock(mode="development")
+    linter = lint.Linter("dependencies.yaml", CONTENT)
+    alpha_spec.check_alpha_spec(linter, args)
+
+    start = CONTENT.find(REPLACED)
+    end = start + len(REPLACED)
+    pos = (start, end)
+
+    expected_linter = lint.Linter("dependencies.yaml", CONTENT)
+    expected_linter.add_warning(
+        pos, "add alpha spec for RAPIDS package cudf"
+    ).add_replacement(pos, "cudf>=24.04,<24.06,>=0.0.0a0")
+    assert linter.warnings == expected_linter.warnings

--- a/test/rapids_pre_commit_hooks/test_alpha_spec.py
+++ b/test/rapids_pre_commit_hooks/test_alpha_spec.py
@@ -412,16 +412,16 @@ def test_check_alpha_spec():
     with patch(
         "rapids_pre_commit_hooks.alpha_spec.check_root", Mock()
     ) as mock_check_root, patch(
-        "yaml.SafeLoader", MagicMock()
-    ) as mock_yaml_safe_loader:
+        "rapids_pre_commit_hooks.alpha_spec.AnchorPreservingLoader", MagicMock()
+    ) as mock_anchor_preserving_loader:
         args = Mock()
         linter = lint.Linter("dependencies.yaml", CONTENT)
         alpha_spec.check_alpha_spec(linter, args)
-    mock_yaml_safe_loader.assert_called_once_with(CONTENT)
+    mock_anchor_preserving_loader.assert_called_once_with(CONTENT)
     mock_check_root.assert_called_once_with(
         linter,
         args,
-        mock_yaml_safe_loader().document_anchors[0],
+        mock_anchor_preserving_loader().document_anchors[0],
         set(),
-        mock_yaml_safe_loader().get_single_node(),
+        mock_anchor_preserving_loader().get_single_node(),
     )


### PR DESCRIPTION
`dependencies.yaml` uses aliases fairly extensively, and we want to properly account for them when checking for alpha specs. If multiple nodes point to the same anchor through an alias, only issue the correction on one of them, and include the anchor name in the correction.