### PR TITLE
Use rapids-metadata

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,6 +18,8 @@
   language: python
   files: dependencies[.]yaml$
   args: [--fix]
+  additional_dependencies:
+    - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
 - id: verify-conda-yes
   name: pass -y/--yes to conda
   description: make sure that all calls to conda pass -y/--yes

--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -10,6 +10,6 @@ python -m build .
 for PKG in dist/*; do
   echo "$PKG"
   pip uninstall -y rapids-pre-commit-hooks
-  pip install "$PKG[test]"
+  pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple "$PKG[test]"
   pytest
 done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "bashlex",
     "gitpython",
     "packaging",
-    "rapids-metadata>=0.2.0,<0.3.0.dev0",
+    "rapids-metadata>=0.3.0,<0.4.0.dev0",
     "rich",
     "tomlkit",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "bashlex",
     "gitpython",
     "packaging",
+    "rapids-metadata>=0.2.0,<0.3.0.dev0",
     "rich",
     "tomlkit",
 ]

--- a/src/rapids_pre_commit_hooks/alpha_spec.py
+++ b/src/rapids_pre_commit_hooks/alpha_spec.py
@@ -12,51 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import re
 from functools import total_ordering
 
 import yaml
 from packaging.requirements import InvalidRequirement, Requirement
+from rapids_metadata import all_metadata
 
 from .lint import LintMain
-
-RAPIDS_ALPHA_SPEC_PACKAGES = {
-    "cubinlinker",
-    "cucim",
-    "cudf",
-    "cugraph",
-    "cugraph-dgl",
-    "cugraph-equivariant",
-    "cugraph-pyg",
-    "cuml",
-    "cuproj",
-    "cuspatial",
-    "cuxfilter",
-    "dask-cuda",
-    "dask-cudf",
-    "distributed-ucxx",
-    "librmm",
-    "libucx",
-    "nx-cugraph",
-    "ptxcompiler",
-    "pylibcugraph",
-    "pylibcugraphops",
-    "pylibraft",
-    "pylibwholegraph",
-    "pynvjitlink",
-    "raft-dask",
-    "rmm",
-    "ucx-py",
-    "ucxx",
-}
-
-RAPIDS_NON_CUDA_SUFFIXED_PACKAGES = {
-    "dask-cuda",
-}
-
-RAPIDS_CUDA_SUFFIXED_PACKAGES = (
-    RAPIDS_ALPHA_SPEC_PACKAGES - RAPIDS_NON_CUDA_SUFFIXED_PACKAGES
-)
 
 ALPHA_SPECIFIER = ">=0.0.0a0"
 
@@ -72,11 +36,12 @@ def node_has_type(node, tag_type):
     return node.tag == f"tag:yaml.org,2002:{tag_type}"
 
 
-def is_rapids_cuda_suffixed_package(name):
-    return any(
-        (match := CUDA_SUFFIX_REGEX.search(name)) and match.group("package") == package
-        for package in RAPIDS_CUDA_SUFFIXED_PACKAGES
-    )
+def strip_cuda_suffix(name):
+    if (match := CUDA_SUFFIX_REGEX.search(name)) and match.group(
+        "package"
+    ) in all_metadata.get_current_version(os.getcwd()).cuda_suffixed_packages:
+        return match.group("package")
+    return name
 
 
 def check_package_spec(linter, args, anchors, used_anchors, node):
@@ -108,8 +73,9 @@ def check_package_spec(linter, args, anchors, used_anchors, node):
             req = Requirement(node.value)
         except InvalidRequirement:
             return
-        if req.name in RAPIDS_ALPHA_SPEC_PACKAGES or is_rapids_cuda_suffixed_package(
-            req.name
+        if (
+            strip_cuda_suffix(req.name)
+            in all_metadata.get_current_version(os.getcwd()).prerelease_packages
         ):
             for key, value in anchors.items():
                 if value == node:

--- a/src/rapids_pre_commit_hooks/alpha_spec.py
+++ b/src/rapids_pre_commit_hooks/alpha_spec.py
@@ -36,7 +36,7 @@ def node_has_type(node, tag_type):
     return node.tag == f"tag:yaml.org,2002:{tag_type}"
 
 
-def strip_cuda_suffix(name):
+def strip_cuda_suffix(name: str) -> str:
     if (match := CUDA_SUFFIX_REGEX.search(name)) and match.group(
         "package"
     ) in all_metadata.get_current_version(os.getcwd()).cuda_suffixed_packages:

--- a/test/rapids_pre_commit_hooks/test_alpha_spec.py
+++ b/test/rapids_pre_commit_hooks/test_alpha_spec.py
@@ -21,12 +21,11 @@ from unittest.mock import MagicMock, Mock, call, patch
 import pytest
 import yaml
 from packaging.version import Version
-from rapids_metadata import all_metadata
 
 from rapids_pre_commit_hooks import alpha_spec, lint
 
 latest_version, latest_metadata = max(
-    all_metadata.versions.items(), key=lambda item: Version(item[0])
+    alpha_spec.all_metadata().versions.items(), key=lambda item: Version(item[0])
 )
 
 
@@ -77,8 +76,9 @@ def test_anchor_preserving_loader():
         ),
     ],
 )
-@patch(
-    "rapids_pre_commit_hooks.alpha_spec.all_metadata.get_current_version",
+@patch.object(
+    alpha_spec.all_metadata(),
+    "get_current_version",
     Mock(return_value=latest_metadata),
 )
 def test_strip_cuda_suffix(name, stripped_name):
@@ -139,8 +139,9 @@ def test_strip_cuda_suffix(name, stripped_name):
         (None, "gcc_linux-64=11.*", "release", None),
     ],
 )
-@patch(
-    "rapids_pre_commit_hooks.alpha_spec.all_metadata.get_current_version",
+@patch.object(
+    alpha_spec.all_metadata(),
+    "get_current_version",
     Mock(return_value=latest_metadata),
 )
 def test_check_package_spec(package, content, mode, replacement):
@@ -168,8 +169,9 @@ def test_check_package_spec(package, content, mode, replacement):
         assert linter.warnings == expected_linter.warnings
 
 
-@patch(
-    "rapids_pre_commit_hooks.alpha_spec.all_metadata.get_current_version",
+@patch.object(
+    alpha_spec.all_metadata(),
+    "get_current_version",
     Mock(return_value=latest_metadata),
 )
 def test_check_package_spec_anchor():


### PR DESCRIPTION
rapids-metadata was created so that we wouldn't have to cut a new pre-commit-hooks release every time the structure of RAPIDS changes. Use rapids-metadata and get rid of the baked-in list of packages.