### PR TITLE
Factor out dependencies for verify-alpha-spec

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -20,6 +20,7 @@
   args: [--fix]
   additional_dependencies:
     - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    - .[alpha-spec]
 - id: verify-conda-yes
   name: pass -y/--yes to conda
   description: make sure that all calls to conda pass -y/--yes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "bashlex",
     "gitpython",
     "packaging",
-    "rapids-metadata>=0.3.0,<0.4.0.dev0",
     "rich",
     "tomlkit",
 ]
@@ -45,6 +44,9 @@ dependencies = [
 test = [
     "freezegun",
     "pytest",
+]
+alpha-spec = [
+    "rapids-metadata>=0.3.0,<0.4.0.dev0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 test = [
     "freezegun",
     "pytest",
+    "rapids-pre-commit-hooks[alpha-spec]",
 ]
 alpha-spec = [
     "rapids-metadata>=0.3.0,<0.4.0.dev0",


### PR DESCRIPTION
Only verify-alpha-spec depends on rapids-metadata right now, so make it an optional dependency list to avoid having to pass the RAPIDS nightly repo for every hook.