### PR TITLE
Add integration test for running pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         args:
         - --show-source
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.0.3
+    rev: v0.1.0
     hooks:
       - id: verify-copyright
         files: |
@@ -58,5 +58,6 @@ repos:
               pyproject[.]toml$
         exclude: |
           (?x)
-              test_copyright[.]py$
+              test_copyright[.]py$|
+              test/examples/
         args: [--fix, --main-branch=main]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "freezegun",
+    "pre-commit",
     "pytest",
     "rapids-pre-commit-hooks[alpha-spec]",
 ]

--- a/test/examples/verify-alpha-spec/fail/master/dependencies.yaml
+++ b/test/examples/verify-alpha-spec/fail/master/dependencies.yaml
@@ -1,0 +1,6 @@
+dependencies:
+  test:
+    common:
+      - output_types: pyproject
+        packages:
+          - cudf>=24.04,<24.06

--- a/test/examples/verify-alpha-spec/pass/master/dependencies.yaml
+++ b/test/examples/verify-alpha-spec/pass/master/dependencies.yaml
@@ -1,0 +1,6 @@
+dependencies:
+  test:
+    common:
+      - output_types: pyproject
+        packages:
+          - cudf>=24.04,<24.06,>=0.0.0a0

--- a/test/examples/verify-conda-yes/fail/master/test.sh
+++ b/test/examples/verify-conda-yes/fail/master/test.sh
@@ -1,0 +1,1 @@
+conda install pkg1

--- a/test/examples/verify-conda-yes/pass/master/test.sh
+++ b/test/examples/verify-conda-yes/pass/master/test.sh
@@ -1,0 +1,1 @@
+conda install -y pkg1

--- a/test/examples/verify-copyright/fail/branch/test.py
+++ b/test/examples/verify-copyright/fail/branch/test.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.
+
+print("New code")

--- a/test/examples/verify-copyright/fail/master/test.py
+++ b/test/examples/verify-copyright/fail/master/test.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.

--- a/test/examples/verify-copyright/pass/branch/test.py
+++ b/test/examples/verify-copyright/pass/branch/test.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+
+print("New code")

--- a/test/examples/verify-copyright/pass/master/test.py
+++ b/test/examples/verify-copyright/pass/master/test.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.

--- a/test/examples/verify-pyproject-license/fail/master/pyproject.toml
+++ b/test/examples/verify-pyproject-license/fail/master/pyproject.toml
@@ -1,0 +1,2 @@
+[project]
+license = { text = "Apache-2.0" }

--- a/test/examples/verify-pyproject-license/pass/master/pyproject.toml
+++ b/test/examples/verify-pyproject-license/pass/master/pyproject.toml
@@ -1,0 +1,2 @@
+[project]
+license = { text = "Apache 2.0" }

--- a/test/test_hooks.py
+++ b/test/test_hooks.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import datetime
+import os.path
+import shutil
+import subprocess
+import sys
+from functools import cache
+
+import git
+import pytest
+import yaml
+from packaging.version import Version
+from rapids_metadata.remote import fetch_latest
+
+REPO_DIR = os.path.join(os.path.dirname(__file__), "..")
+with open(os.path.join(REPO_DIR, ".pre-commit-hooks.yaml")) as f:
+    ALL_HOOKS = [hook["id"] for hook in yaml.safe_load(f)]
+EXAMPLES_DIR = os.path.join(os.path.dirname(__file__), "examples")
+
+
+@cache
+def all_metadata():
+    return fetch_latest()
+
+
+@contextlib.contextmanager
+def set_cwd(cwd):
+    old_cwd = os.getcwd()
+    os.chdir(cwd)
+    try:
+        yield
+    finally:
+        os.chdir(old_cwd)
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    repo = git.Repo.init(tmp_path)
+    with repo.config_writer() as w:
+        w.set_value("user", "name", "RAPIDS Test Fixtures")
+        w.set_value("user", "email", "testfixtures@rapids.ai")
+    return repo
+
+
+def run_hook(git_repo, hook_name, expected_status, exc):
+    def list_files(top):
+        for dirpath, _, filenames in os.walk(top):
+            for filename in filenames:
+                yield filename if top == dirpath else os.path.join(
+                    os.path.relpath(top, dirpath), filename
+                )
+
+    example_dir = os.path.join(EXAMPLES_DIR, hook_name, expected_status)
+    master_dir = os.path.join(example_dir, "master")
+    shutil.copytree(master_dir, git_repo.working_tree_dir, dirs_exist_ok=True)
+
+    with open(os.path.join(git_repo.working_tree_dir, "VERSION"), "w") as f:
+        f.write(f"{max(all_metadata().versions.keys(), key=Version)}\n")
+    git_repo.index.add("VERSION")
+
+    git_repo.index.add(list_files(master_dir))
+    git_repo.index.commit(
+        "Initial commit",
+        commit_date=datetime.datetime(2023, 2, 1, tzinfo=datetime.timezone.utc),
+    )
+
+    branch_dir = os.path.join(example_dir, "branch")
+    if os.path.exists(branch_dir):
+        git_repo.head.reference = git_repo.create_head("branch", git_repo.head.commit)
+        git_repo.index.remove(list_files(master_dir), working_tree=True)
+        shutil.copytree(branch_dir, git_repo.working_tree_dir, dirs_exist_ok=True)
+        git_repo.index.add(list_files(branch_dir))
+        git_repo.index.commit(
+            "Make some changes",
+            commit_date=datetime.datetime(2024, 2, 1, tzinfo=datetime.timezone.utc),
+        )
+
+    with set_cwd(git_repo.working_tree_dir), pytest.raises(
+        exc
+    ) if exc else contextlib.nullcontext():
+        subprocess.check_call(
+            [sys.executable, "-m", "pre_commit", "try-repo", REPO_DIR, hook_name, "-a"],
+            env={**os.environ, "TARGET_BRANCH": "master"},
+        )
+
+
+@pytest.mark.parametrize(
+    "hook_name",
+    ALL_HOOKS,
+)
+def test_hook_pass(git_repo, hook_name):
+    run_hook(git_repo, hook_name, "pass", None)
+
+
+@pytest.mark.parametrize(
+    "hook_name",
+    ALL_HOOKS,
+)
+def test_hook_fail(git_repo, hook_name):
+    run_hook(git_repo, hook_name, "fail", subprocess.CalledProcessError)

--- a/test/test_pre_commit.py
+++ b/test/test_pre_commit.py
@@ -56,7 +56,7 @@ def git_repo(tmp_path):
     return repo
 
 
-def run_hook(git_repo, hook_name, expected_status, exc):
+def run_pre_commit(git_repo, hook_name, expected_status, exc):
     def list_files(top):
         for dirpath, _, filenames in os.walk(top):
             for filename in filenames:
@@ -102,13 +102,13 @@ def run_hook(git_repo, hook_name, expected_status, exc):
     "hook_name",
     ALL_HOOKS,
 )
-def test_hook_pass(git_repo, hook_name):
-    run_hook(git_repo, hook_name, "pass", None)
+def test_pre_commit_pass(git_repo, hook_name):
+    run_pre_commit(git_repo, hook_name, "pass", None)
 
 
 @pytest.mark.parametrize(
     "hook_name",
     ALL_HOOKS,
 )
-def test_hook_fail(git_repo, hook_name):
-    run_hook(git_repo, hook_name, "fail", subprocess.CalledProcessError)
+def test_pre_commit_fail(git_repo, hook_name):
+    run_pre_commit(git_repo, hook_name, "fail", subprocess.CalledProcessError)


### PR DESCRIPTION
Dependency issues in .pre-commit-hooks.yaml previously caused hooks other than verify-alpha-spec to fail to install. Add an integration test where we actually run pre-commit with every hook to avoid such issues in the future.