### PR TITLE
Display notice when copyrighted file is copied or renamed

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -20,6 +20,6 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Build & Test
         run: ./ci/build-test.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "PyYAML",
     "bashlex",

--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -60,7 +60,10 @@ def strip_copyright(content: str, copyright_matches: list[re.Match]) -> list[str
 
 
 def add_copy_rename_note(
-    linter: Linter, warning: LintWarning, change_type: str, old_filename: Optional[str]
+    linter: Linter,
+    warning: LintWarning,
+    change_type: str,
+    old_filename: Optional[Union[str, os.PathLike[str]]],
 ):
     CHANGE_VERBS = {
         "C": "copied",
@@ -79,7 +82,7 @@ def add_copy_rename_note(
 def apply_copyright_revert(
     linter: Linter,
     change_type: str,
-    old_filename: Optional[str],
+    old_filename: Optional[Union[str, os.PathLike[str]]],
     old_match: re.Match,
     new_match: re.Match,
 ) -> None:
@@ -98,7 +101,7 @@ def apply_copyright_revert(
 def apply_copyright_update(
     linter: Linter,
     change_type: str,
-    old_filename: Optional[str],
+    old_filename: Optional[Union[str, os.PathLike[str]]],
     match: re.Match,
     year: int,
 ) -> None:
@@ -116,7 +119,7 @@ def apply_copyright_update(
 def apply_copyright_check(
     linter: Linter,
     change_type: str,
-    old_filename: Optional[str],
+    old_filename: Optional[Union[str, os.PathLike[str]]],
     old_content: Optional[str],
 ) -> None:
     if linter.content != old_content:
@@ -363,7 +366,7 @@ def check_copyright(
             old_filename = None
             old_content = None
         else:
-            old_filename = changed_file.name
+            old_filename = changed_file.path
             old_content = changed_file.data_stream.read().decode()
         apply_copyright_check(linter, change_type, old_filename, old_content)
 

--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -75,7 +75,14 @@ def add_copy_rename_note(
         pass
     else:
         warning.add_note(
-            (0, len(linter.content)), f"file was {change_verb} from '{old_filename}'"
+            (0, len(linter.content)),
+            f"file was {change_verb} from '{old_filename}' and is assumed to share "
+            "history with it",
+        )
+        warning.add_note(
+            (0, len(linter.content)),
+            "change file contents if you want its copyright dates to only be "
+            "determined by its own edit history",
         )
 
 
@@ -100,8 +107,6 @@ def apply_copyright_revert(
 
 def apply_copyright_update(
     linter: Linter,
-    change_type: str,
-    old_filename: Optional[Union[str, os.PathLike[str]]],
     match: re.Match,
     year: int,
 ) -> None:
@@ -113,7 +118,6 @@ def apply_copyright_update(
             last_year=year,
         ),
     )
-    add_copy_rename_note(linter, w, change_type, old_filename)
 
 
 def apply_copyright_check(
@@ -145,9 +149,7 @@ def apply_copyright_check(
                     int(match.group("last_year") or match.group("first_year"))
                     < current_year
                 ):
-                    apply_copyright_update(
-                        linter, change_type, old_filename, match, current_year
-                    )
+                    apply_copyright_update(linter, match, current_year)
         else:
             linter.add_warning((0, 0), "no copyright notice found")
 

--- a/src/rapids_pre_commit_hooks/lint.py
+++ b/src/rapids_pre_commit_hooks/lint.py
@@ -19,23 +19,11 @@ import dataclasses
 import functools
 import re
 import warnings
-from typing import Callable, Generator, Iterable, Optional
+from itertools import pairwise
+from typing import Callable, Optional
 
 from rich.console import Console
 from rich.markup import escape
-
-
-# Taken from Python docs
-# (https://docs.python.org/3.12/library/itertools.html#itertools.pairwise)
-# Replace with itertools.pairwise after dropping Python 3.9 support
-def _pairwise(iterable: Iterable) -> Generator:
-    # pairwise('ABCDEFG') → AB BC CD DE EF FG
-    iterator = iter(iterable)
-    a = next(iterator, None)
-    for b in iterator:
-        yield a, b
-        a = b
-
 
 _PosType = tuple[int, int]
 
@@ -101,7 +89,7 @@ class Linter:
             key=lambda replacement: replacement.pos,
         )
 
-        for r1, r2 in _pairwise(sorted_replacements):
+        for r1, r2 in pairwise(sorted_replacements):
             if r1.pos[1] > r2.pos[0]:
                 raise OverlappingReplacementsError(f"{r1} overlaps with {r2}")
 

--- a/src/rapids_pre_commit_hooks/lint.py
+++ b/src/rapids_pre_commit_hooks/lint.py
@@ -65,9 +65,9 @@ class LintWarning:
     pos: _PosType
     msg: str
     replacements: list[Replacement] = dataclasses.field(
-        default_factory=list, init=False
+        default_factory=list, kw_only=True
     )
-    notes: list[Note] = dataclasses.field(default_factory=list, init=False)
+    notes: list[Note] = dataclasses.field(default_factory=list, kw_only=True)
 
     def add_replacement(self, pos: _PosType, newtext: str) -> None:
         self.replacements.append(Replacement(pos, newtext))

--- a/test/rapids_pre_commit_hooks/test_copyright.py
+++ b/test/rapids_pre_commit_hooks/test_copyright.py
@@ -291,9 +291,6 @@ def test_strip_copyright():
                 LintWarning(
                     (15, 24),
                     "copyright is out of date",
-                    notes=[
-                        Note((0, 185), "file was renamed from 'file1.txt'"),
-                    ],
                     replacements=[
                         Replacement(
                             (1, 43), "Copyright (c) 2021-2024, NVIDIA CORPORATION"
@@ -303,9 +300,6 @@ def test_strip_copyright():
                 LintWarning(
                     (58, 62),
                     "copyright is out of date",
-                    notes=[
-                        Note((0, 185), "file was renamed from 'file1.txt'"),
-                    ],
                     replacements=[
                         Replacement(
                             (44, 81), "Copyright (c) 2023-2024, NVIDIA CORPORATION"
@@ -340,9 +334,6 @@ def test_strip_copyright():
                 LintWarning(
                     (15, 24),
                     "copyright is out of date",
-                    notes=[
-                        Note((0, 185), "file was copied from 'file1.txt'"),
-                    ],
                     replacements=[
                         Replacement(
                             (1, 43), "Copyright (c) 2021-2024, NVIDIA CORPORATION"
@@ -352,9 +343,6 @@ def test_strip_copyright():
                 LintWarning(
                     (58, 62),
                     "copyright is out of date",
-                    notes=[
-                        Note((0, 185), "file was copied from 'file1.txt'"),
-                    ],
                     replacements=[
                         Replacement(
                             (44, 81), "Copyright (c) 2023-2024, NVIDIA CORPORATION"
@@ -362,6 +350,54 @@ def test_strip_copyright():
                     ],
                 ),
             ],
+        ),
+        (
+            "R",
+            "file1.txt",
+            dedent(
+                r"""
+                Copyright (c) 2021-2023 NVIDIA CORPORATION
+                Copyright (c) 2023 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA CORPORATION
+                This file has not been changed
+                """
+            ),
+            "file2.txt",
+            dedent(
+                r"""
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2023-2024 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA CORPORATION
+                This file has been changed
+                """
+            ),
+            [],
+        ),
+        (
+            "C",
+            "file1.txt",
+            dedent(
+                r"""
+                Copyright (c) 2021-2023 NVIDIA CORPORATION
+                Copyright (c) 2023 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA CORPORATION
+                This file has not been changed
+                """
+            ),
+            "file2.txt",
+            dedent(
+                r"""
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2023-2024 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA CORPORATION
+                This file has been changed
+                """
+            ),
+            [],
         ),
         (
             "R",
@@ -390,7 +426,16 @@ def test_strip_copyright():
                     (15, 24),
                     "copyright is not out of date and should not be updated",
                     notes=[
-                        Note((0, 189), "file was renamed from 'file1.txt'"),
+                        Note(
+                            (0, 189),
+                            "file was renamed from 'file1.txt' and is assumed to "
+                            "share history with it",
+                        ),
+                        Note(
+                            (0, 189),
+                            "change file contents if you want its copyright dates to "
+                            "only be determined by its own edit history",
+                        ),
                     ],
                     replacements=[
                         Replacement(
@@ -402,7 +447,16 @@ def test_strip_copyright():
                     (120, 157),
                     "copyright is not out of date and should not be updated",
                     notes=[
-                        Note((0, 189), "file was renamed from 'file1.txt'"),
+                        Note(
+                            (0, 189),
+                            "file was renamed from 'file1.txt' and is assumed to "
+                            "share history with it",
+                        ),
+                        Note(
+                            (0, 189),
+                            "change file contents if you want its copyright dates to "
+                            "only be determined by its own edit history",
+                        ),
                     ],
                     replacements=[
                         Replacement(
@@ -439,7 +493,16 @@ def test_strip_copyright():
                     (15, 24),
                     "copyright is not out of date and should not be updated",
                     notes=[
-                        Note((0, 189), "file was copied from 'file1.txt'"),
+                        Note(
+                            (0, 189),
+                            "file was copied from 'file1.txt' and is assumed to share "
+                            "history with it",
+                        ),
+                        Note(
+                            (0, 189),
+                            "change file contents if you want its copyright dates to "
+                            "only be determined by its own edit history",
+                        ),
                     ],
                     replacements=[
                         Replacement(
@@ -451,7 +514,16 @@ def test_strip_copyright():
                     (120, 157),
                     "copyright is not out of date and should not be updated",
                     notes=[
-                        Note((0, 189), "file was copied from 'file1.txt'"),
+                        Note(
+                            (0, 189),
+                            "file was copied from 'file1.txt' and is assumed to share "
+                            "history with it",
+                        ),
+                        Note(
+                            (0, 189),
+                            "change file contents if you want its copyright dates to "
+                            "only be determined by its own edit history",
+                        ),
                     ],
                     replacements=[
                         Replacement(

--- a/test/rapids_pre_commit_hooks/test_copyright.py
+++ b/test/rapids_pre_commit_hooks/test_copyright.py
@@ -1147,11 +1147,12 @@ def test_check_copyright(git_repo):
             """
         )
 
+    os.mkdir(os.path.join(git_repo.working_tree_dir, "dir"))
     write_file("file1.txt", file_contents(1))
-    write_file("file2.txt", file_contents(2))
+    write_file("dir/file2.txt", file_contents(2))
     write_file("file3.txt", file_contents(3))
     write_file("file4.txt", file_contents(4))
-    git_repo.index.add(["file1.txt", "file2.txt", "file3.txt", "file4.txt"])
+    git_repo.index.add(["file1.txt", "dir/file2.txt", "file3.txt", "file4.txt"])
     git_repo.index.commit("Initial commit")
 
     branch_1 = git_repo.create_head("branch-1", "master")
@@ -1164,8 +1165,8 @@ def test_check_copyright(git_repo):
     branch_2 = git_repo.create_head("branch-2", "master")
     git_repo.head.reference = branch_2
     git_repo.head.reset(index=True, working_tree=True)
-    write_file("file2.txt", file_contents_modified(2))
-    git_repo.index.add(["file2.txt"])
+    write_file("dir/file2.txt", file_contents_modified(2))
+    git_repo.index.add(["dir/file2.txt"])
     git_repo.index.commit("Update file2.txt")
 
     pr = git_repo.create_head("pr", "branch-1")
@@ -1177,7 +1178,7 @@ def test_check_copyright(git_repo):
     write_file("file4.txt", file_contents_modified(4))
     git_repo.index.add(["file4.txt"])
     git_repo.index.commit("Update file4.txt")
-    git_repo.index.move(["file2.txt", "file5.txt"])
+    git_repo.index.move(["dir/file2.txt", "file5.txt"])
     git_repo.index.commit("Rename file2.txt to file5.txt")
 
     write_file("file6.txt", file_contents(6))
@@ -1215,7 +1216,7 @@ def test_check_copyright(git_repo):
     with mock_apply_copyright_check() as apply_copyright_check:
         copyright_checker(linter, mock_args)
         apply_copyright_check.assert_called_once_with(
-            linter, "R", "file2.txt", file_contents(2)
+            linter, "R", "dir/file2.txt", file_contents(2)
         )
 
     linter = Linter("file3.txt", file_contents_modified(3))
@@ -1274,7 +1275,7 @@ def test_check_copyright(git_repo):
     with mock_apply_copyright_check() as apply_copyright_check:
         copyright_checker(linter, mock_args)
         apply_copyright_check.assert_called_once_with(
-            linter, "R", "file2.txt", file_contents(2)
+            linter, "R", "dir/file2.txt", file_contents(2)
         )
 
     linter = Linter("file3.txt", file_contents_modified(3))

--- a/test/rapids_pre_commit_hooks/test_copyright.py
+++ b/test/rapids_pre_commit_hooks/test_copyright.py
@@ -879,23 +879,23 @@ def test_get_changed_files(git_repo):
     ):
         changed_files = copyright.get_changed_files(Mock())
     assert {
-        path: (old_blob[0], old_blob[1].path if old_blob[1] else None)
-        for path, old_blob in changed_files.items()
+        path: (change_type, old_blob.path if old_blob else None)
+        for path, (change_type, old_blob) in changed_files.items()
     } == changed | superfluous
 
-    for new, old in changed.items():
-        if old[1]:
+    for new, (_, old) in changed.items():
+        if old:
             with open(fn(new), "rb") as f:
                 new_contents = f.read()
-            old_contents = old_files[old[1]].data_stream.read()
+            old_contents = old_files[old].data_stream.read()
             assert new_contents != old_contents
             assert changed_files[new][1].data_stream.read() == old_contents
 
-    for new, old in superfluous.items():
-        if old[1]:
+    for new, (_, old) in superfluous.items():
+        if old:
             with open(fn(new), "rb") as f:
                 new_contents = f.read()
-            old_contents = old_files[old[1]].data_stream.read()
+            old_contents = old_files[old].data_stream.read()
             assert new_contents == old_contents
             assert changed_files[new][1].data_stream.read() == old_contents
 
@@ -970,8 +970,8 @@ def test_get_changed_files_multiple_merge_bases(git_repo):
     ):
         changed_files = copyright.get_changed_files(Mock())
     assert {
-        path: (old_blob[0], old_blob[1].path if old_blob[1] else None)
-        for path, old_blob in changed_files.items()
+        path: (change_type, old_blob.path if old_blob else None)
+        for path, (change_type, old_blob) in changed_files.items()
     } == {
         "file1.txt": ("M", "file1.txt"),
         "file2.txt": ("M", "file2.txt"),

--- a/test/rapids_pre_commit_hooks/test_copyright.py
+++ b/test/rapids_pre_commit_hooks/test_copyright.py
@@ -363,6 +363,104 @@ def test_strip_copyright():
                 ),
             ],
         ),
+        (
+            "R",
+            "file1.txt",
+            dedent(
+                r"""
+                Copyright (c) 2021-2023 NVIDIA CORPORATION
+                Copyright (c) 2023 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA CORPORATION
+                This file has not been changed
+                """
+            ),
+            "file2.txt",
+            dedent(
+                r"""
+                Copyright (c) 2021-2024 NVIDIA CORPORATION
+                Copyright (c) 2023 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA Corporation
+                This file has not been changed
+                """
+            ),
+            [
+                LintWarning(
+                    (15, 24),
+                    "copyright is not out of date and should not be updated",
+                    notes=[
+                        Note((0, 189), "file was renamed from 'file1.txt'"),
+                    ],
+                    replacements=[
+                        Replacement(
+                            (1, 43), "Copyright (c) 2021-2023 NVIDIA CORPORATION"
+                        ),
+                    ],
+                ),
+                LintWarning(
+                    (120, 157),
+                    "copyright is not out of date and should not be updated",
+                    notes=[
+                        Note((0, 189), "file was renamed from 'file1.txt'"),
+                    ],
+                    replacements=[
+                        Replacement(
+                            (120, 157), "Copyright (c) 2025 NVIDIA CORPORATION"
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        (
+            "C",
+            "file1.txt",
+            dedent(
+                r"""
+                Copyright (c) 2021-2023 NVIDIA CORPORATION
+                Copyright (c) 2023 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA CORPORATION
+                This file has not been changed
+                """
+            ),
+            "file2.txt",
+            dedent(
+                r"""
+                Copyright (c) 2021-2024 NVIDIA CORPORATION
+                Copyright (c) 2023 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA Corporation
+                This file has not been changed
+                """
+            ),
+            [
+                LintWarning(
+                    (15, 24),
+                    "copyright is not out of date and should not be updated",
+                    notes=[
+                        Note((0, 189), "file was copied from 'file1.txt'"),
+                    ],
+                    replacements=[
+                        Replacement(
+                            (1, 43), "Copyright (c) 2021-2023 NVIDIA CORPORATION"
+                        ),
+                    ],
+                ),
+                LintWarning(
+                    (120, 157),
+                    "copyright is not out of date and should not be updated",
+                    notes=[
+                        Note((0, 189), "file was copied from 'file1.txt'"),
+                    ],
+                    replacements=[
+                        Replacement(
+                            (120, 157), "Copyright (c) 2025 NVIDIA CORPORATION"
+                        ),
+                    ],
+                ),
+            ],
+        ),
     ],
 )
 @freeze_time("2024-01-18")

--- a/test/rapids_pre_commit_hooks/test_copyright.py
+++ b/test/rapids_pre_commit_hooks/test_copyright.py
@@ -23,7 +23,7 @@ import pytest
 from freezegun import freeze_time
 
 from rapids_pre_commit_hooks import copyright
-from rapids_pre_commit_hooks.lint import Linter, LintWarning, Replacement
+from rapids_pre_commit_hooks.lint import Linter, LintWarning, Note, Replacement
 
 
 def test_match_copyright():
@@ -260,6 +260,104 @@ def test_strip_copyright():
                     replacements=[
                         Replacement(
                             (120, 157), "Copyright (c) 2025 NVIDIA CORPORATION"
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        (
+            "R",
+            "file1.txt",
+            dedent(
+                r"""
+                Copyright (c) 2021-2023 NVIDIA CORPORATION
+                Copyright (c) 2023 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA CORPORATION
+                This file has not been changed
+                """
+            ),
+            "file2.txt",
+            dedent(
+                r"""
+                Copyright (c) 2021-2023 NVIDIA CORPORATION
+                Copyright (c) 2023 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA CORPORATION
+                This file has been changed
+                """
+            ),
+            [
+                LintWarning(
+                    (15, 24),
+                    "copyright is out of date",
+                    notes=[
+                        Note((0, 185), "file was renamed from 'file1.txt'"),
+                    ],
+                    replacements=[
+                        Replacement(
+                            (1, 43), "Copyright (c) 2021-2024, NVIDIA CORPORATION"
+                        ),
+                    ],
+                ),
+                LintWarning(
+                    (58, 62),
+                    "copyright is out of date",
+                    notes=[
+                        Note((0, 185), "file was renamed from 'file1.txt'"),
+                    ],
+                    replacements=[
+                        Replacement(
+                            (44, 81), "Copyright (c) 2023-2024, NVIDIA CORPORATION"
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        (
+            "C",
+            "file1.txt",
+            dedent(
+                r"""
+                Copyright (c) 2021-2023 NVIDIA CORPORATION
+                Copyright (c) 2023 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA CORPORATION
+                This file has not been changed
+                """
+            ),
+            "file2.txt",
+            dedent(
+                r"""
+                Copyright (c) 2021-2023 NVIDIA CORPORATION
+                Copyright (c) 2023 NVIDIA CORPORATION
+                Copyright (c) 2024 NVIDIA CORPORATION
+                Copyright (c) 2025 NVIDIA CORPORATION
+                This file has been changed
+                """
+            ),
+            [
+                LintWarning(
+                    (15, 24),
+                    "copyright is out of date",
+                    notes=[
+                        Note((0, 185), "file was copied from 'file1.txt'"),
+                    ],
+                    replacements=[
+                        Replacement(
+                            (1, 43), "Copyright (c) 2021-2024, NVIDIA CORPORATION"
+                        ),
+                    ],
+                ),
+                LintWarning(
+                    (58, 62),
+                    "copyright is out of date",
+                    notes=[
+                        Note((0, 185), "file was copied from 'file1.txt'"),
+                    ],
+                    replacements=[
+                        Replacement(
+                            (44, 81), "Copyright (c) 2023-2024, NVIDIA CORPORATION"
                         ),
                     ],
                 ),


### PR DESCRIPTION
Also proposes requiring Python 3.10, since https://github.com/rapidsai/build-planning/issues/88 is being rolled out.

Fixes https://github.com/rapidsai/pre-commit-hooks/issues/48