### PR TITLE
Use collections.abc.Callable instead of typing.Callable

### DIFF
--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -18,7 +18,8 @@ import functools
 import os
 import re
 import warnings
-from typing import Callable, Optional, Union
+from collections.abc import Callable
+from typing import Optional, Union
 
 import git
 

--- a/src/rapids_pre_commit_hooks/lint.py
+++ b/src/rapids_pre_commit_hooks/lint.py
@@ -19,8 +19,8 @@ import dataclasses
 import functools
 import re
 import warnings
-from collections.abc import Callable
-from typing import Generator, Iterable, Optional
+from collections.abc import Callable, Generator, Iterable
+from typing import Optional
 
 from rich.console import Console
 from rich.markup import escape

--- a/src/rapids_pre_commit_hooks/lint.py
+++ b/src/rapids_pre_commit_hooks/lint.py
@@ -19,7 +19,8 @@ import dataclasses
 import functools
 import re
 import warnings
-from typing import Callable, Generator, Iterable, Optional
+from collections.abc import Callable
+from typing import Generator, Iterable, Optional
 
 from rich.console import Console
 from rich.markup import escape


### PR DESCRIPTION
`typing.Callable` has been deprecated since Python 3.9. Switch to `collections.abc.Callable`. Also switch to `collections.abc.Generator` and `collections.abc.Iterable`.