### PR TITLE
Fix copyright year in pre-commit test

### DIFF
--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -127,7 +127,14 @@ def apply_copyright_check(
     old_content: str | None,
 ) -> None:
     if linter.content != old_content:
-        current_year = datetime.datetime.now().year
+        year_env = os.getenv("RAPIDS_TEST_YEAR")
+        if year_env:
+            try:
+                current_year = int(year_env)
+            except ValueError:
+                current_year = datetime.datetime.now().year
+        else:
+            current_year = datetime.datetime.now().year
         new_copyright_matches = match_copyright(linter.content)
 
         if old_content is not None:

--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -321,8 +321,6 @@ def get_changed_files(
             elif diff.change_type != "D":
                 assert diff.b_path is not None
                 assert diff.change_type is not None
-                a_blob = diff.a_blob
-                assert isinstance(a_blob, git.Blob)
                 changed_files[diff.b_path] = (diff.change_type, diff.a_blob)
 
     return changed_files

--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -316,8 +316,13 @@ def get_changed_files(
         )
         for diff in diffs:
             if diff.change_type == "A":
+                assert diff.b_path is not None
                 changed_files[diff.b_path] = (diff.change_type, None)
             elif diff.change_type != "D":
+                assert diff.b_path is not None
+                assert diff.change_type is not None
+                a_blob = diff.a_blob
+                assert isinstance(a_blob, git.Blob)
                 changed_files[diff.b_path] = (diff.change_type, diff.a_blob)
 
     return changed_files

--- a/test/test_pre_commit.py
+++ b/test/test_pre_commit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ def run_pre_commit(git_repo, hook_name, expected_status, exc):
     ):
         subprocess.check_call(
             [sys.executable, "-m", "pre_commit", "try-repo", REPO_DIR, hook_name, "-a"],
-            env={**os.environ, "TARGET_BRANCH": "master"},
+            env={**os.environ, "TARGET_BRANCH": "master", "RAPIDS_TEST_YEAR": "2024"},
         )
 
 


### PR DESCRIPTION
The copyright test uses the current date, rather than the file modification date. Mock the current date in the pre-commit test.