### PR TITLE
Make codeowners rules optional by group

### DIFF
--- a/src/rapids_pre_commit_hooks/codeowners.py
+++ b/src/rapids_pre_commit_hooks/codeowners.py
@@ -120,13 +120,16 @@ REQUIRED_CMAKE_CODEOWNERS_LINES = required_codeowners_list(
         ),
     ],
 )
-REQUIRED_CODEOWNERS_LINES = [
-    *REQUIRED_CI_CODEOWNERS_LINES,
-    *REQUIRED_PACKAGING_CODEOWNERS_LINES,
-    *REQUIRED_CPP_CODEOWNERS_LINES,
-    *REQUIRED_PYTHON_CODEOWNERS_LINES,
-    *REQUIRED_CMAKE_CODEOWNERS_LINES,
-]
+
+
+def required_codeowners_lines(args: argparse.Namespace) -> list[RequiredCodeownersLine]:
+    return [
+        *(REQUIRED_CI_CODEOWNERS_LINES if args.ci else []),
+        *(REQUIRED_PACKAGING_CODEOWNERS_LINES if args.packaging else []),
+        *(REQUIRED_CPP_CODEOWNERS_LINES if args.cpp else []),
+        *(REQUIRED_PYTHON_CODEOWNERS_LINES if args.python else []),
+        *(REQUIRED_CMAKE_CODEOWNERS_LINES if args.cmake else []),
+    ]
 
 
 def parse_codeowners_line(line: str, skip: int) -> CodeownersLine | None:
@@ -164,7 +167,7 @@ def check_codeowners_line(
     codeowners_line: CodeownersLine,
     found_files: list[tuple[RequiredCodeownersLine, tuple[int, int]]],
 ) -> None:
-    for required_codeowners_line in REQUIRED_CODEOWNERS_LINES:
+    for required_codeowners_line in required_codeowners_lines(args):
         if required_codeowners_line.file == codeowners_line.file.filename:
             required_owners = [
                 required_owner(project_prefix=args.project_prefix)
@@ -229,7 +232,7 @@ def check_codeowners(linter: Linter, args: argparse.Namespace) -> None:
             check_codeowners_line(linter, args, codeowners_line, found_files)
 
     new_text = ""
-    for required_codeowners_line in REQUIRED_CODEOWNERS_LINES:
+    for required_codeowners_line in required_codeowners_lines(args):
         if required_codeowners_line.file not in map(
             lambda line: line[0].file, found_files
         ):
@@ -257,6 +260,36 @@ def main() -> None:
         metavar="<project prefix>",
         help="project prefix to insert for project-specific team names",
         required=True,
+    )
+    m.argparser.add_argument(
+        "--ci",
+        help="enforce rules for CI codeowners",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    m.argparser.add_argument(
+        "--packaging",
+        help="enforce rules for packaging codeowners",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    m.argparser.add_argument(
+        "--cpp",
+        help="enforce rules for C++ codeowners",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    m.argparser.add_argument(
+        "--python",
+        help="enforce rules for Python codeowners",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    m.argparser.add_argument(
+        "--cmake",
+        help="enforce rules for CMake codeowners",
+        action=argparse.BooleanOptionalAction,
+        default=True,
     )
     with m.execute() as ctx:
         ctx.add_check(check_codeowners)

--- a/src/rapids_pre_commit_hooks/codeowners.py
+++ b/src/rapids_pre_commit_hooks/codeowners.py
@@ -68,7 +68,9 @@ def project_codeowners(category: str) -> CodeownersTransform:
 def required_codeowners_list(
     files: list[str], owners: list[CodeownersTransform], after: list[str] = []
 ) -> list[RequiredCodeownersLine]:
-    return [RequiredCodeownersLine(file=file, owners=owners) for file in files]
+    return [
+        RequiredCodeownersLine(file=file, owners=owners, after=after) for file in files
+    ]
 
 
 REQUIRED_CI_CODEOWNERS_LINES = required_codeowners_list(

--- a/test/rapids_pre_commit_hooks/test_codeowners.py
+++ b/test/rapids_pre_commit_hooks/test_codeowners.py
@@ -38,8 +38,8 @@ MOCK_REQUIRED_CODEOWNERS_LINES = [
 ]
 
 patch_required_codeowners_lines = patch(
-    "rapids_pre_commit_hooks.codeowners.REQUIRED_CODEOWNERS_LINES",
-    MOCK_REQUIRED_CODEOWNERS_LINES,
+    "rapids_pre_commit_hooks.codeowners.required_codeowners_lines",
+    lambda _args: MOCK_REQUIRED_CODEOWNERS_LINES,
 )
 
 


### PR DESCRIPTION
Also use the `after` argument in `required_codeowners_list()`, which wasn't being used before.