### PR TITLE
WIP: add shellcheck to pre-commit, simplify testing script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.6.0'
+    rev: 'v5.0.0'
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -27,18 +27,18 @@ repos:
       - id: mixed-line-ending
         args: [--fix=lf]
   - repo: https://github.com/asottile/pyupgrade
-    rev: 'v3.17.0'
+    rev: 'v3.20.0'
     hooks:
       - id: pyupgrade
         args:
           - --py310-plus
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.3
+    rev: v0.11.13
     hooks:
       - id: ruff
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.11.2'
+    rev: 'v1.16.0'
     hooks:
       - id: mypy
         args:
@@ -59,8 +59,13 @@ repos:
           - rich
           - tomlkit
           - types-PyYAML
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.4.0
+    rev: v0.6.0
     hooks:
       - id: verify-copyright
         files: |

--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -3,13 +3,12 @@
 
 set -ue
 
-pip install build
+# According to https://pre-commit.com/#python,
+# pre-commit will install the package with 'pip install .' from the repo root.
+#
+# So this installs it the same way.
+pip install \
+  --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple \
+  .[test]
 
-python -m build .
-
-for PKG in dist/*; do
-  echo "$PKG"
-  pip uninstall -y rapids-pre-commit-hooks
-  pip install --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple "$PKG[test]"
-  pytest
-done
+pytest

--- a/tests/examples/verify-conda-yes/fail/master/test.sh
+++ b/tests/examples/verify-conda-yes/fail/master/test.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 conda install pkg1

--- a/tests/examples/verify-conda-yes/pass/master/test.sh
+++ b/tests/examples/verify-conda-yes/pass/master/test.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 conda install -y pkg1


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/135

Adds `shellcheck` to `pre-commit`, to catch issues like unsafe access patterns, unused variables, etc. in shell scripts.

Fixes these warnings:

```text
SC1087 (error): Use braces when expanding arrays, e.g. ${array[idx]} (or ${var}[.. to quiet)
SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.
```

Also updates all other hooks with `pre-commit autoupdate`.
