### PR TITLE
Add `--rapids-version-file` argument to `verify-alpha-spec`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ test = [
     "rapids-pre-commit-hooks[alpha-spec]",
 ]
 alpha-spec = [
-    "rapids-metadata>=0.3.0,<0.4.0.dev0",
+    "rapids-metadata>=0.4.0,<0.5.0.dev0",
 ]
 
 [project.scripts]

--- a/src/rapids_pre_commit_hooks/alpha_spec.py
+++ b/src/rapids_pre_commit_hooks/alpha_spec.py
@@ -48,7 +48,7 @@ def get_rapids_version(args: argparse.Namespace) -> "RAPIDSVersion":
     return (
         md.versions[args.rapids_version]
         if args.rapids_version
-        else md.get_current_version(os.getcwd())
+        else md.get_current_version(os.getcwd(), args.rapids_version_file)
     )
 
 
@@ -349,6 +349,12 @@ def main() -> None:
         "--rapids-version",
         help="Specify a RAPIDS version to use instead of reading from the "
         "VERSION file",
+    )
+    m.argparser.add_argument(
+        "--rapids-version-file",
+        help="Specify a file to read the RAPIDS version from instead of "
+        "VERSION",
+        default="VERSION",
     )
     with m.execute() as ctx:
         ctx.add_check(check_alpha_spec)


### PR DESCRIPTION
This will allow us to more easily support projects like ucxx, which use a different versioning scheme but still store their RAPIDS version in a separate file.