### PR TITLE
Use `main` branch by default

### DIFF
--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -789,7 +789,7 @@ def main() -> None:
     m.argparser.add_argument(
         "--main-branch",
         metavar="<main branch>",
-        help="main branch to use instead of branch-<major>.<minor>",
+        help="main branch to use (defaults to main)",
         default="main",
     )
     m.argparser.add_argument(


### PR DESCRIPTION
With https://github.com/rapidsai/build-planning/issues/224 being rolled out, use `main` by default instead of `branch-xx.yy`.