### PR TITLE
Add `FORCE_SPDX` environment variable

### DIFF
--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -115,7 +115,9 @@ class ConflictingFilesWarning(RuntimeWarning):
 
 
 def force_spdx(args: argparse.Namespace) -> bool:
-    return args.force_spdx or bool(int(os.getenv("FORCE_SPDX", default="0")))
+    return args.force_spdx or bool(
+        int(os.getenv("RAPIDS_COPYRIGHT_FORCE_SPDX", default="0"))
+    )
 
 
 def match_copyright(

--- a/tests/rapids_pre_commit_hooks/test_copyright.py
+++ b/tests/rapids_pre_commit_hooks/test_copyright.py
@@ -98,7 +98,7 @@ def test_force_spdx(arg, env, raises, expected_value):
     with (
         patch.dict(
             "os.environ",
-            {"FORCE_SPDX": env} if env is not None else {},
+            {"RAPIDS_COPYRIGHT_FORCE_SPDX": env} if env is not None else {},
             clear=True,
         ),
         raises,


### PR DESCRIPTION
Using the `--force-spdx` argument is error-prone, since it frequently sneaks into pull requests. Add an environment variable to accomplish the same task.