### PR TITLE
Allow affiliates changes on copyright notices

### DIFF
--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -360,8 +360,8 @@ def apply_copyright_revert(
         "copyright is not out of date and should not be updated",
     )
     w.add_replacement(
-        new_match.full_copyright_text_span,
-        old_content[slice(*old_match.full_copyright_text_span)],
+        new_match.nvidia_copyright_text_span,
+        old_content[slice(*old_match.nvidia_copyright_text_span)],
     )
     add_copy_rename_note(linter, w, change_type, old_filename)
 
@@ -686,9 +686,11 @@ def apply_copyright_check(
                     old_copyright_matches, new_copyright_matches
                 ):
                     if (
-                        old_content[slice(*old_match.full_copyright_text_span)]
+                        old_content[
+                            slice(*old_match.nvidia_copyright_text_span)
+                        ]
                         != linter.content[
-                            slice(*new_match.full_copyright_text_span)
+                            slice(*new_match.nvidia_copyright_text_span)
                         ]
                     ):
                         apply_copyright_revert(

--- a/tests/rapids_pre_commit_hooks/test_copyright.py
+++ b/tests/rapids_pre_commit_hooks/test_copyright.py
@@ -1197,6 +1197,27 @@ def test_strip_copyright(content, expected_stripped):
             id="unchanged-with-copyright-update",
         ),
         pytest.param(
+            "M",
+            "file.txt",
+            dedent(
+                f"""
+                Copyright (c) {2021}-{2023} NVIDIA CORPORATION
+                This file has not been changed
+                """
+            ),
+            "file.txt",
+            dedent(
+                f"""
+                Copyright (c) {2021}-{2023} NVIDIA CORPORATION. All rights reserved.
+                This file has not been changed
+                """  # noqa: E501
+            ),
+            False,
+            False,
+            [],
+            id="unchanged-with-copyright-affiliates-update",
+        ),
+        pytest.param(
             "R",
             "file1.txt",
             dedent(


### PR DESCRIPTION
Sometimes we want to change the affiliates of the copyright line without changing the year or anything else. Relax the "file unchanged" rule slightly to allow such changes.