### PR TITLE
Handle cases of more than one `next-line` directive

### DIFF
--- a/src/rapids_pre_commit_hooks/lint.py
+++ b/src/rapids_pre_commit_hooks/lint.py
@@ -140,7 +140,7 @@ class Linter:
     _DISABLE_ENABLE_DIRECTIVE_RE: re.Pattern = re.compile(
         r"\brapids-pre-commit-hooks: *"
         r"(?P<directive_name>enable|disable)"
-        r"(?:-(?P<scope>next-line))?\b"
+        r"(?:-(?P<scope>next-line))?(?P<word_boundary>\b)?"
         r"(?: *\[(?P<warning_names>[\w-]+(?:,[\w-]+)*)\])?"
     )
 
@@ -309,6 +309,8 @@ class Linter:
             for m in Linter._DISABLE_ENABLE_DIRECTIVE_RE.finditer(
                 lines.content
             ):
+                if m.group("word_boundary") is None:
+                    continue
                 if m.group("warning_names") and warning_name not in m.group(
                     "warning_names"
                 ).split(","):

--- a/tests/rapids_pre_commit_hooks/test_lint.py
+++ b/tests/rapids_pre_commit_hooks/test_lint.py
@@ -418,6 +418,10 @@ class TestLinter:
                 : ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~0
                 + # rapids-pre-commit-hooks: enabled
                 : ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~0
+                + # rapids-pre-commit-hooks: enable-next-lines
+                : ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~0
+                + Hello
+                : ~~~~~~0
                 """,
                 "test",
                 [True],


### PR DESCRIPTION
The directive system was ignoring all but the last `next-line` directive inside a block. Ensure it handles all of them. Also fix an issue with a lack of word boundary after `next-line` directives.