### PR TITLE
Add suppression instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@ Copy the following into your repository's `.pre-commit-config.yaml`:
   hooks:  # Hook names to use
     - id: verify-copyright
 ```
+
+## Suppressing false positives
+
+Some checks are prone to false positives, particularly `verify-hardcoded-version`. In such
+cases, you can use `rapids-pre-commit-hooks: disable`, `rapids-pre-commit-hooks: enable`, and
+`rapids-pre-commit-hooks: disable-next-line` directives:
+
+```python
+def deprecated_function():
+    # rapids-pre-commit-hooks: disable[verify-hardcoded-version]
+    """Do some deprecated stuff
+
+    .. deprecated:: Deprecated in 26.04
+    """
+    # rapids-pre-commit-hooks: enable[verify-hardcoded-version]
+
+    # rapids-pre-commit-hooks: disable-next-line[verify-hardcoded-version]
+    warnings.warn("deprecated_function() has been deprecated since 26.04")
+```
+
 ## Included hooks
 
 All hooks are listed in `.pre-commit-hooks.yaml`.

--- a/src/rapids_pre_commit_hooks/hardcoded_version.py
+++ b/src/rapids_pre_commit_hooks/hardcoded_version.py
@@ -164,6 +164,13 @@ def check_hardcoded_version(
             match.span("full"),
             f"do not hard-code version, read from {args.version_file} "
             "file instead",
+        ).add_note(
+            match.span("full"),
+            "if this is intentional (as part of a docstring or deprecation "
+            "notice), suppress it with rapids-pre-commit-hooks: "
+            "disable-next-line - see "
+            "https://github.com/rapidsai/pre-commit-hooks/blob/main/README.md"
+            "#suppressing-false-positives for details",
         )
 
 

--- a/tests/rapids_pre_commit_hooks/test_hardcoded_version.py
+++ b/tests/rapids_pre_commit_hooks/test_hardcoded_version.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from rapids_pre_commit_hooks import hardcoded_version
-from rapids_pre_commit_hooks.lint import Lines, LintWarning, Linter
+from rapids_pre_commit_hooks.lint import Lines, LintWarning, Linter, Note
 from rapids_pre_commit_hooks_test_utils import parse_named_ranges
 
 
@@ -687,4 +687,20 @@ def test_check_hardcoded_version(
         mock_read_version_file.assert_called_once_with(version_file)
     else:
         mock_read_version_file.assert_not_called()
-    assert linter.warnings == [LintWarning(m, message) for m in r]
+    assert linter.warnings == [
+        LintWarning(
+            m,
+            message,
+            notes=[
+                Note(
+                    m,
+                    "if this is intentional (as part of a docstring or "
+                    "deprecation notice), suppress it with "
+                    "rapids-pre-commit-hooks: disable-next-line - see "
+                    "https://github.com/rapidsai/pre-commit-hooks/blob/main/"
+                    "README.md#suppressing-false-positives for details",
+                )
+            ],
+        )
+        for m in r
+    ]


### PR DESCRIPTION
`verify-hardcoded-version` is very prone to false positives, so give clear instructions on how to suppress it when needed.