### PR TITLE
verify-pyproject-license: handle out-of-order tables

### DIFF
--- a/src/rapids_pre_commit_hooks/pyproject_license.py
+++ b/src/rapids_pre_commit_hooks/pyproject_license.py
@@ -38,8 +38,11 @@ def check_pyproject_license(linter: Linter, _args: argparse.Namespace) -> None:
             loc = (len(linter.content), len(linter.content))
             linter.add_warning(
                 loc,
-                "[project] table should proceed all other [project.*] tables"
-                + " and all [project.*] tables should be grouped together.",
+                (
+                    "[project] table should precede all other [project.*] "
+                    "tables and all [project.*] tables should be grouped "
+                    "together"
+                ),
             )
             return
 

--- a/tests/rapids_pre_commit_hooks/test_pyproject_license.py
+++ b/tests/rapids_pre_commit_hooks/test_pyproject_license.py
@@ -221,8 +221,8 @@ from rapids_pre_commit_hooks_test_utils import parse_named_ranges
             :                   ^warning
             """,
             (
-                "[project] table should proceed all other [project.*] tables "
-                "and all [project.*] tables should be grouped together."
+                "[project] table should precede all other [project.*] tables "
+                "and all [project.*] tables should be grouped together"
             ),
             None,
             id="project-table-and-non-contiguous-subtables",


### PR DESCRIPTION
Fixes #105

`verify-pyproject-license` currently breaks on `pyproject.toml` files where there are non-`[project*]` tables between the first and last `[project*]`, like this:

```shell
cat > ./pyproject-example.toml <<EOF
[project]
name = "example"

[tool.ruff]
line-length = 88

[project.urls]
Homepage = "https://github.com/rapidsai"
EOF

pip install -e .
verify-pyproject-license ./pyproject-example.toml
# AttributeError: 'OutOfOrderTableProxy' object has no attribute 'is_super_table'
```

This proposes warning and existing early in that case. So now the `verify-pyproject-license` hook will just enforce that all tables belonging to the same top-level table be grouped together in `pyproject.toml`.

## Notes for Reviewers

Discovered while trying to add `verify-pyproject-license` in `kvikio`. `libkvikio`'s pyproject.toml has some `[tool.*]` tables between `[project]` and `[project.entrypoint."cmake.prefix"]`:

https://github.com/rapidsai/kvikio/blob/2c273a92524b7f2a19a89c6784fca2418fc49031/python/libkvikio/pyproject.toml#L60

Tested this fix there like this:

```diff
diff --git a/.pre-commit-config.yaml b/.pre-commit-config.yaml
index 33066fd..f221a3d 100644
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,8 +73,8 @@ repos:
           (?x)^(
             ^CHANGELOG.md$
           )
-  - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.3.1
+  - repo: https://github.com/jameslamb/pre-commit-hooks
+    rev: 6ea3661662966c68b8b2614b2f6c9e1621c1f3b6
     hooks:
       - id: verify-copyright
         args: [--fix, --spdx]
@@ -105,6 +105,12 @@ repos:
             ^conda/environments/|
             [.](png)$|
             ^cpp/examples/downstream/cmake/get_kvikio[.]cmake$
+      - id: verify-pyproject-license
+        # ignore the top-level pyproject.toml, which doesn't
+        # have or need a [project] table
+        exclude: |
+          (?x)
+            ^pyproject[.]toml$
```

Saw this fail and raise the expected warning

<img width="666" height="212" alt="image" src="https://github.com/user-attachments/assets/30fd8132-4af5-40b3-9691-7e14e1fde402" />
