### PR TITLE
Improve verify-hardcoded-version heuristics

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,7 +17,7 @@
   language: python
   files:
     (?x)
-        ^[.]github/CODEOWNERS$
+      ^[.]github/CODEOWNERS$
   args: [--fix]
 - id: verify-conda-yes
   name: pass -y/--yes to conda
@@ -33,12 +33,12 @@
   language: python
   files: |
     (?x)
-        [.](cmake|cpp|cu|cuh|h|hpp|sh|pxd|py|pyx|rs|java)$|
-        CMakeLists[.]txt$|
-        CMakeLists_standalone[.]txt$|
-        meta[.]yaml$|
-        pyproject[.]toml$|
-        setup[.]cfg$
+      [.](cmake|cpp|cu|cuh|h|hpp|sh|pxd|py|pyx|rs|java)$|
+      (^|/)CMakeLists[.]txt$|
+      (^|/)CMakeLists_standalone[.]txt$|
+      (^|/)meta[.]yaml$|
+      (^|/)pyproject[.]toml$|
+      (^|/)setup[.]cfg$
   args: [--fix]
 - id: verify-hardcoded-version
   name: verify-hardcoded-version
@@ -48,13 +48,13 @@
   args: [--fix]
   exclude: |
     (?x)
-      devcontainer[.]json$|
-      dependencies[.]yaml$|
-      ^[.]github/workflows/|
-      [.]md$|
-      pom[.]xml$|
+      (^|/)devcontainer[.]json$|
+      (^|/)dependencies[.]yaml$|
+      ^[.]github/(workflows|ISSUE_TEMPLATE)/|
+      (^|/)pom[.]xml$|
       ^[.]pre-commit-config[.]yaml$|
-      [.]rst$
+      ^conda/environments/|
+      [.](md|rst|avro|parquet|png|orc|gz|pkl|sas7bdat)$
 - id: verify-pyproject-license
   name: verify-pyproject-license
   description: make sure pyproject.toml license is correct
@@ -62,5 +62,5 @@
   language: python
   files: |
     (?x)
-        pyproject[.]toml$
+      (^|/)pyproject[.]toml$
   args: [--fix]

--- a/src/rapids_pre_commit_hooks/hardcoded_version.py
+++ b/src/rapids_pre_commit_hooks/hardcoded_version.py
@@ -36,6 +36,7 @@ HARDCODED_VERSION_RE: re.Pattern = re.compile(
 PYPROJECT_TOML_RE: re.Pattern = re.compile(r"(?:^|/)pyproject\.toml$")
 DEPRECATED_RE: re.Pattern = re.compile(r"\.\. deprecated::|@deprecated")
 NUMBER_ARRAY_RE: re.Pattern = re.compile(r"^[ .,0-9-]*$")
+VERSION_DOC_RE: re.Pattern = re.compile(r"\b(?:in|since|after) $")
 
 
 def get_excluded_section_pyproject_toml(
@@ -85,10 +86,16 @@ def is_number_array(lines: "Lines", match: "re.Match[str]") -> bool:
     return bool(NUMBER_ARRAY_RE.search(lines.content[start:end]))
 
 
+def is_version_doc(lines: "Lines", match: "re.Match[str]") -> bool:
+    return bool(VERSION_DOC_RE.search(lines.content[: match.start()]))
+
+
 def skip_heuristics(lines: "Lines", match: "re.Match[str]") -> bool:
     if is_deprecation_notice(lines, match):
         return True
     if is_number_array(lines, match):
+        return True
+    if is_version_doc(lines, match):
         return True
     return False
 


### PR DESCRIPTION
Skip instances of the version preceded by "in", "since", or "after", and exclude some more files by default.