### PR TITLE
Fix version doc heuristics

### DIFF
--- a/src/rapids_pre_commit_hooks/hardcoded_version.py
+++ b/src/rapids_pre_commit_hooks/hardcoded_version.py
@@ -73,7 +73,7 @@ def get_excluded_sections(linter: Linter) -> "Generator[tuple[int, int]]":
 
 
 def is_deprecation_notice(lines: "Lines", match: "re.Match[str]") -> bool:
-    this_line = lines.line_for_pos(match.start())
+    this_line = lines.line_for_pos(match.start("full"))
     first_line = max(0, this_line - 3)
     start = lines.pos[first_line][0]
     end = lines.pos[this_line][1]
@@ -81,13 +81,13 @@ def is_deprecation_notice(lines: "Lines", match: "re.Match[str]") -> bool:
 
 
 def is_number_array(lines: "Lines", match: "re.Match[str]") -> bool:
-    this_line = lines.line_for_pos(match.start())
+    this_line = lines.line_for_pos(match.start("full"))
     start, end = lines.pos[this_line]
     return bool(NUMBER_ARRAY_RE.search(lines.content[start:end]))
 
 
 def is_version_doc(lines: "Lines", match: "re.Match[str]") -> bool:
-    return bool(VERSION_DOC_RE.search(lines.content[: match.start()]))
+    return bool(VERSION_DOC_RE.search(lines.content[: match.start("full")]))
 
 
 def skip_heuristics(lines: "Lines", match: "re.Match[str]") -> bool:

--- a/tests/rapids_pre_commit_hooks/test_hardcoded_version.py
+++ b/tests/rapids_pre_commit_hooks/test_hardcoded_version.py
@@ -333,11 +333,14 @@ def test_is_version_doc(content, expected_value):
     content, ranges = parse_named_ranges(content)
     match_range = ranges["match"]
     lines = Lines(content)
+    start = Mock(return_value=match_range[0])
+    end = Mock(return_value=match_range[1])
     match = Mock(
-        start=Mock(return_value=match_range[0]),
-        end=Mock(return_value=match_range[1]),
+        start=start,
+        end=end,
     )
     assert hardcoded_version.is_version_doc(lines, match) == expected_value
+    start.assert_called_once_with("full")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The version doc heuristics were ending at the wrong character. End at the start of the `full` match rather than the whole match.