### PR TITLE
Support doc heuristics for TODO, versionadded, in release, and similar

### DIFF
--- a/src/rapids_pre_commit_hooks/hardcoded_version.py
+++ b/src/rapids_pre_commit_hooks/hardcoded_version.py
@@ -102,7 +102,7 @@ def is_todo_doc(lines: "Lines", match: "re.Match[str]") -> bool:
     start, end = lines.spans[this_line]
     todo_match = TODO_DOC_RE.search(lines.content[start:end])
     return (
-        bool(todo_match)
+        todo_match is not None
         and todo_match.start("version") == start + match.start("full")
         and todo_match.end("version") == start + match.end("full")
     )

--- a/src/rapids_pre_commit_hooks/hardcoded_version.py
+++ b/src/rapids_pre_commit_hooks/hardcoded_version.py
@@ -34,11 +34,14 @@ HARDCODED_VERSION_RE: re.Pattern = re.compile(
 )
 
 PYPROJECT_TOML_RE: re.Pattern = re.compile(r"(?:^|/)pyproject\.toml$")
-DEPRECATED_RE: re.Pattern = re.compile(r"\.\. deprecated::|@deprecated")
+DEPRECATED_VERSIONADD_RE: re.Pattern = re.compile(
+    r"\.\. (deprecated|versionchanged|versionadded)::|@deprecated"
+)
 NUMBER_ARRAY_RE: re.Pattern = re.compile(r"^[ .,0-9-]*$")
 VERSION_DOC_RE: re.Pattern = re.compile(
-    r"\b(?:in|since|after) (?:version )?$", re.IGNORECASE
+    r"\b(?:in|since|after) (?:(version|release) )?$", re.IGNORECASE
 )
+TODO_DOC_RE: re.Pattern = re.compile(r"TODO\((\d{1,2}|\.)*\)")
 
 
 def get_excluded_span_pyproject_toml(
@@ -74,12 +77,12 @@ def get_excluded_spans(linter: Linter) -> "Generator[Span]":
         yield from get_excluded_spans_pyproject_toml(linter)
 
 
-def is_deprecation_notice(lines: "Lines", match: "re.Match[str]") -> bool:
+def is_deprecation_versionadd(lines: "Lines", match: "re.Match[str]") -> bool:
     this_line = lines.line_for_pos(match.start("full"))
     first_line = max(0, this_line - 3)
     start = lines.spans[first_line][0]
     end = lines.spans[this_line][1]
-    return bool(DEPRECATED_RE.search(lines.content[start:end]))
+    return bool(DEPRECATED_VERSIONADD_RE.search(lines.content[start:end]))
 
 
 def is_number_array(lines: "Lines", match: "re.Match[str]") -> bool:
@@ -92,12 +95,20 @@ def is_version_doc(lines: "Lines", match: "re.Match[str]") -> bool:
     return bool(VERSION_DOC_RE.search(lines.content[: match.start("full")]))
 
 
+def is_todo_doc(lines: "Lines", match: "re.Match[str]") -> bool:
+    this_line = lines.line_for_pos(match.start("full"))
+    start, end = lines.spans[this_line]
+    return bool(TODO_DOC_RE.search(lines.content[start:end]))
+
+
 def skip_heuristics(lines: "Lines", match: "re.Match[str]") -> bool:
-    if is_deprecation_notice(lines, match):
+    if is_deprecation_versionadd(lines, match):
         return True
     if is_number_array(lines, match):
         return True
     if is_version_doc(lines, match):
+        return True
+    if is_todo_doc(lines, match):
         return True
     return False
 

--- a/src/rapids_pre_commit_hooks/hardcoded_version.py
+++ b/src/rapids_pre_commit_hooks/hardcoded_version.py
@@ -35,13 +35,15 @@ HARDCODED_VERSION_RE: re.Pattern = re.compile(
 
 PYPROJECT_TOML_RE: re.Pattern = re.compile(r"(?:^|/)pyproject\.toml$")
 DEPRECATED_VERSIONADD_RE: re.Pattern = re.compile(
-    r"\.\. (deprecated|versionchanged|versionadded)::|@deprecated"
+    r"\.\. (?:deprecated|versionchanged|versionadded)::|@deprecated"
 )
 NUMBER_ARRAY_RE: re.Pattern = re.compile(r"^[ .,0-9-]*$")
 VERSION_DOC_RE: re.Pattern = re.compile(
-    r"\b(?:in|since|after) (?:(version|release) )?$", re.IGNORECASE
+    r"\b(?:in|since|after) (?:(?:version|release) )?$", re.IGNORECASE
 )
-TODO_DOC_RE: re.Pattern = re.compile(r"TODO\((\d{1,2}|\.)*\)")
+TODO_DOC_RE: re.Pattern = re.compile(
+    r"TODO\((?P<version>\d{1,2}+(?:\.\d{1,2})+)\)"
+)
 
 
 def get_excluded_span_pyproject_toml(
@@ -98,7 +100,12 @@ def is_version_doc(lines: "Lines", match: "re.Match[str]") -> bool:
 def is_todo_doc(lines: "Lines", match: "re.Match[str]") -> bool:
     this_line = lines.line_for_pos(match.start("full"))
     start, end = lines.spans[this_line]
-    return bool(TODO_DOC_RE.search(lines.content[start:end]))
+    todo_match = TODO_DOC_RE.search(lines.content[start:end])
+    return (
+        bool(todo_match)
+        and todo_match.start("version") == start + match.start("full")
+        and todo_match.end("version") == start + match.end("full")
+    )
 
 
 def skip_heuristics(lines: "Lines", match: "re.Match[str]") -> bool:

--- a/tests/rapids_pre_commit_hooks/test_hardcoded_version.py
+++ b/tests/rapids_pre_commit_hooks/test_hardcoded_version.py
@@ -183,6 +183,22 @@ def test_get_excluded_spans(filename, content):
         ),
         pytest.param(
             """\
+            + .. versionadded:: 26.04
+            :                   ~~~~~match
+            """,
+            True,
+            id="versionadded",
+        ),
+        pytest.param(
+            """\
+            + .. versionchanged:: 26.04
+            :                     ~~~~~match
+            """,
+            True,
+            id="versionchanged",
+        ),
+        pytest.param(
+            """\
             + /**
             +  * @brief Compute the edit distance between all the strings in the input column.
             +  *
@@ -218,7 +234,7 @@ def test_get_excluded_spans(filename, content):
         ),
     ],
 )
-def test_is_deprecation_notice(content, expected_value):
+def test_is_deprecation_versionadd(content, expected_value):
     content, spans = parse_named_spans(content)
     match_span = spans["match"]
     lines = Lines(content)
@@ -227,7 +243,8 @@ def test_is_deprecation_notice(content, expected_value):
         end=Mock(return_value=match_span[1]),
     )
     assert (
-        hardcoded_version.is_deprecation_notice(lines, match) == expected_value
+        hardcoded_version.is_deprecation_versionadd(lines, match)
+        == expected_value
     )
 
 
@@ -321,6 +338,14 @@ def test_is_number_array(content, expected_value):
         ),
         pytest.param(
             """\
+            + after release 26.04
+            :               ~~~~~match
+            """,
+            True,
+            id="with-release-word",
+        ),
+        pytest.param(
+            """\
             + In 26.04
             :    ~~~~~match
             """,
@@ -334,6 +359,14 @@ def test_is_number_array(content, expected_value):
             """,
             True,
             id="capitalized-with-version-word",
+        ),
+        pytest.param(
+            """\
+            + After release 26.04
+            :               ~~~~~match
+            """,
+            True,
+            id="capitalized-with-release-word",
         ),
         pytest.param(
             """\
@@ -368,14 +401,51 @@ def test_is_version_doc(content, expected_value):
 
 
 @pytest.mark.parametrize(
+    ["content", "expected_value"],
     [
-        "is_deprecation_notice",
+        pytest.param(
+            """\
+            + TODO(26.04)
+            :      ~~~~~match
+            """,
+            True,
+            id="todo",
+        ),
+        pytest.param(
+            """\
+            + TODO something else 26.04
+            :                     ~~~~~match
+            """,
+            False,
+            id="todo-unrelated",
+        ),
+    ],
+)
+def test_is_todo_doc(content, expected_value):
+    content, spans = parse_named_spans(content)
+    match_span = spans["match"]
+    lines = Lines(content)
+    start = Mock(return_value=match_span[0])
+    end = Mock(return_value=match_span[1])
+    match = Mock(
+        start=start,
+        end=end,
+    )
+    assert hardcoded_version.is_todo_doc(lines, match) == expected_value
+    start.assert_called_once_with("full")
+
+
+@pytest.mark.parametrize(
+    [
+        "is_deprecation_versionadd",
         "is_number_array",
         "is_version_doc",
+        "is_todo_doc",
         "expected_value",
     ],
     [
         pytest.param(
+            False,
             False,
             False,
             False,
@@ -386,12 +456,14 @@ def test_is_version_doc(content, expected_value):
             True,
             False,
             False,
+            False,
             True,
             id="is-deprecation-notice",
         ),
         pytest.param(
             False,
             True,
+            False,
             False,
             True,
             id="is-number-array",
@@ -400,18 +472,31 @@ def test_is_version_doc(content, expected_value):
             False,
             False,
             True,
+            False,
             True,
             id="is-version-doc",
+        ),
+        pytest.param(
+            False,
+            False,
+            False,
+            True,
+            True,
+            id="is_todo_doc",
         ),
     ],
 )
 def test_skip_heuristics(
-    is_deprecation_notice, is_number_array, is_version_doc, expected_value
+    is_deprecation_versionadd,
+    is_number_array,
+    is_version_doc,
+    is_todo_doc,
+    expected_value,
 ):
     with (
         patch(
-            "rapids_pre_commit_hooks.hardcoded_version.is_deprecation_notice",
-            Mock(return_value=is_deprecation_notice),
+            "rapids_pre_commit_hooks.hardcoded_version.is_deprecation_versionadd",
+            Mock(return_value=is_deprecation_versionadd),
         ),
         patch(
             "rapids_pre_commit_hooks.hardcoded_version.is_number_array",
@@ -420,6 +505,10 @@ def test_skip_heuristics(
         patch(
             "rapids_pre_commit_hooks.hardcoded_version.is_version_doc",
             Mock(return_value=is_version_doc),
+        ),
+        patch(
+            "rapids_pre_commit_hooks.hardcoded_version.is_todo_doc",
+            Mock(return_value=is_todo_doc),
         ),
     ):
         assert (

--- a/tests/rapids_pre_commit_hooks/test_hardcoded_version.py
+++ b/tests/rapids_pre_commit_hooks/test_hardcoded_version.py
@@ -419,6 +419,14 @@ def test_is_version_doc(content, expected_value):
             False,
             id="todo-unrelated",
         ),
+        pytest.param(
+            """\
+            + TODO(unrelated): filler 26.04
+            :                         ~~~~~match
+            """,
+            False,
+            id="todo",
+        ),
     ],
 )
 def test_is_todo_doc(content, expected_value):

--- a/tests/rapids_pre_commit_hooks/test_hardcoded_version.py
+++ b/tests/rapids_pre_commit_hooks/test_hardcoded_version.py
@@ -432,7 +432,6 @@ def test_is_todo_doc(content, expected_value):
         end=end,
     )
     assert hardcoded_version.is_todo_doc(lines, match) == expected_value
-    start.assert_called_once_with("full")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #124 by updating existing heuristics to support the mentioned cases and adds a new heuristic for "TODO" docstrings.