### PR TITLE
verify-copyright: detect C-style comment usage for more file types

### DIFF
--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -35,7 +35,7 @@ SPDX_COPYRIGHT_RE: re.Pattern = re.compile(
     r"(?P<spdx_license_identifier_text>[^\r\n]+))?"
 )
 C_STYLE_COMMENTS_RE: re.Pattern = re.compile(
-    r"\.(?:c|cc|cpp|cxx|cu|cuh|go|groovy|h|hpp|hxx|i|js|java|rs|ts|tsx)$"
+    r"\.(?:c|cc|cpp|css|cu|cuh|cxx|go|groovy|h|hpp|hxx|i|js|java|rs|ts|tsx)$"
 )
 CMAKE_FILENAME_RE: re.Pattern = re.compile(
     r"(?:\.cmake|(?:^|/)CMakeLists\.txt)$"

--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -35,7 +35,7 @@ SPDX_COPYRIGHT_RE: re.Pattern = re.compile(
     r"(?P<spdx_license_identifier_text>[^\r\n]+))?"
 )
 C_STYLE_COMMENTS_RE: re.Pattern = re.compile(
-    r"\.(?:c|cpp|cxx|cu|h|hpp|hxx|cuh|js|java|rs)$"
+    r"\.(?:c|cc|cpp|cxx|cu|cuh|go|groovy|h|hpp|hxx|i|js|java|rs|ts|tsx)$"
 )
 CMAKE_FILENAME_RE: re.Pattern = re.compile(
     r"(?:\.cmake|(?:^|/)CMakeLists\.txt)$"

--- a/tests/rapids_pre_commit_hooks/test_copyright.py
+++ b/tests/rapids_pre_commit_hooks/test_copyright.py
@@ -581,6 +581,16 @@ def test_match_all_copyright(content):
             " * ",
             id="c-style-comment-in-c-style-file",
         ),
+        pytest.param(
+            """\
+            +
+            + /* Comment
+            :    ^pos
+            """,
+            "file.ts",
+            " * ",
+            id="c-style-comment-in-typescript-file",
+        ),
     ],
 )
 def test_compute_prefix(content, filename, expected_prefix):


### PR DESCRIPTION
Working on https://github.com/rapidsai/jupyterlab-nvdashboard/issues/259, I found myself wanting to use `verify-copyright` on a bunch of TypeScript files.

TypeScript supports C-style comments, but this hook tries to add `#` comments.

This expands the list of extensions known to support C-style comments, adding:

* `cc` = C++
* `css` = CSS
* `go` = Go
* `groovy` = Groovy
* `i` = SWIG
* `ts` / `tsx` = TypeScript