### PR TITLE
feat: add support for missing web development file types

### DIFF
--- a/src/rapids_pre_commit_hooks/copyright.py
+++ b/src/rapids_pre_commit_hooks/copyright.py
@@ -35,7 +35,7 @@ SPDX_COPYRIGHT_RE: re.Pattern = re.compile(
     r"(?P<spdx_license_identifier_text>[^\r\n]+))?"
 )
 C_STYLE_COMMENTS_RE: re.Pattern = re.compile(
-    r"\.(?:c|cc|cpp|css|cu|cuh|cxx|go|groovy|h|hpp|hxx|i|js|java|rs|ts|tsx)$"
+    r"\.(?:c|cc|cjs|cpp|css|cu|cuh|cxx|go|groovy|h|hpp|hxx|i|js|java|jsx|mjs|rs|scss|ts|tsx)$"
 )
 CMAKE_FILENAME_RE: re.Pattern = re.compile(
     r"(?:\.cmake|(?:^|/)CMakeLists\.txt)$"

--- a/tests/rapids_pre_commit_hooks/test_copyright.py
+++ b/tests/rapids_pre_commit_hooks/test_copyright.py
@@ -591,6 +591,46 @@ def test_match_all_copyright(content):
             " * ",
             id="c-style-comment-in-typescript-file",
         ),
+        pytest.param(
+            """\
+            +
+            + /* Comment
+            :    ^pos
+            """,
+            "file.scss",
+            " * ",
+            id="c-style-comment-in-scss-file",
+        ),
+        pytest.param(
+            """\
+            +
+            + /* Comment
+            :    ^pos
+            """,
+            "file.jsx",
+            " * ",
+            id="c-style-comment-in-jsx-file",
+        ),
+        pytest.param(
+            """\
+            +
+            + /* Comment
+            :    ^pos
+            """,
+            "file.mjs",
+            " * ",
+            id="c-style-comment-in-mjs-file",
+        ),
+        pytest.param(
+            """\
+            +
+            + /* Comment
+            :    ^pos
+            """,
+            "file.cjs",
+            " * ",
+            id="c-style-comment-in-cjs-file",
+        ),
     ],
 )
 def test_compute_prefix(content, filename, expected_prefix):


### PR DESCRIPTION
While adding this to some `heavyai` repositories we are going to open source, I noticed it lacked support for some common file types. This adds support for the following types:
- `jsx`
- `scss`
- `cjs`
- `mjs`