### PR TITLE
Limit supporte values of `--org` for `verify-codeowners`

### DIFF
--- a/src/rapids_pre_commit_hooks/codeowners.py
+++ b/src/rapids_pre_commit_hooks/codeowners.py
@@ -293,6 +293,7 @@ def main() -> None:
         metavar="<organization>",
         help="name of organization the project belongs to",
         default="rapidsai",
+        choices=["rapidsai", "NVIDIA"],
     )
     m.argparser.add_argument(
         "--ci",


### PR DESCRIPTION
The argument was already implicitly limited to these values due to how the code is structured, but codify the limitation in the arguments.