### PR TITLE
More refactoring for `dependencies.yaml` handling

### DIFF
--- a/src/rapids_pre_commit_hooks/utils/dependencies_yaml.py
+++ b/src/rapids_pre_commit_hooks/utils/dependencies_yaml.py
@@ -123,7 +123,7 @@ class ChainedHandler(Handler):
     @contextlib.contextmanager
     def _handle_context(
         self, hook_name, *args
-    ) -> "Generator[tuple[contextlib.AbstractContextManager[Any], ...]]":
+    ) -> "Generator[tuple[Any, ...]]":
         with contextlib.ExitStack() as context:
             yield tuple(
                 context.enter_context(getattr(handler, hook_name)(*args))

--- a/src/rapids_pre_commit_hooks/utils/dependencies_yaml.py
+++ b/src/rapids_pre_commit_hooks/utils/dependencies_yaml.py
@@ -2,9 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
 import yaml
+
+from .yaml import AnchorPreservingLoader, check_and_mark_anchor, node_has_type
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class Handler:
@@ -108,50 +113,147 @@ class Handler:
         pass
 
 
-class AnchorPreservingLoader(yaml.SafeLoader):
-    """A SafeLoader that preserves the anchors for later reference. The anchors
-    can be found in the document_anchors member, which is a list of
-    dictionaries, one dictionary for each parsed document.
-    """
+class ChainedHandler(Handler):
+    def __init__(self) -> None:
+        self.handlers: "list[Handler]" = []
 
-    def __init__(self, stream) -> None:
-        super().__init__(stream)
-        self.document_anchors: list[dict[str, yaml.Node]] = []
+    def add_handler(self, handler: "Handler") -> None:
+        self.handlers.append(handler)
 
-    def compose_document(self) -> "yaml.Node":
-        # Drop the DOCUMENT-START event.
-        self.get_event()
+    @contextlib.contextmanager
+    def _handle_context(
+        self, hook_name, *args
+    ) -> "Generator[tuple[contextlib.AbstractContextManager[Any], ...]]":
+        with contextlib.ExitStack() as context:
+            yield tuple(
+                context.enter_context(getattr(handler, hook_name)(*args))
+                for handler in self.handlers
+            )
 
-        # Compose the root node.
-        node = self.compose_node(None, None)  # type: ignore[arg-type]
+    def _handle_no_context(self, hook_name, *args) -> None:
+        for handler in self.handlers:
+            getattr(handler, hook_name)(*args)
 
-        # Drop the DOCUMENT-END event.
-        self.get_event()
+    def handle_root(
+        self,
+        value: "yaml.Node",  # noqa: ARG002
+    ) -> "contextlib.AbstractContextManager[tuple[Any, ...]]":
+        return self._handle_context("handle_root", value)
 
-        self.document_anchors.append(self.anchors)
-        self.anchors = {}
-        assert node is not None
-        return node
+    def handle_dependencies(
+        self,
+        root_context: "Any",
+        key: "yaml.Node",  # noqa: ARG002
+        value: "yaml.Node",  # noqa: ARG002
+    ) -> "contextlib.AbstractContextManager[tuple[Any, ...]]":
+        return self._handle_context(
+            "handle_dependencies", root_context, key, value
+        )
 
+    def handle_dependency_set(
+        self,
+        dependencies_context: "Any",
+        key: "yaml.Node",  # noqa: ARG002
+        value: "yaml.Node",  # noqa: ARG002
+    ) -> "contextlib.AbstractContextManager[Any]":
+        return self._handle_context(
+            "handle_dependency_set", dependencies_context, key, value
+        )
 
-def node_has_type(node: "yaml.Node", tag_type: str) -> bool:
-    return node.tag == f"tag:yaml.org,2002:{tag_type}"
+    def handle_common(
+        self,
+        dependency_set_context: "Any",
+        key: "yaml.Node",  # noqa: ARG002
+        value: "yaml.Node",  # noqa: ARG002
+    ) -> "contextlib.AbstractContextManager[Any]":
+        return self._handle_context(
+            "handle_common", dependency_set_context, key, value
+        )
 
+    def handle_common_item(
+        self,
+        common_context: "Any",
+        item: "yaml.Node",  # noqa: ARG002
+    ) -> "contextlib.AbstractContextManager[Any]":
+        return self._handle_context("handle_common_item", common_context, item)
 
-def check_and_mark_anchor(
-    anchors: dict[str, "yaml.Node"], used_anchors: set[str], node: "yaml.Node"
-) -> tuple[bool, str | None]:
-    for key, value in anchors.items():
-        if value == node:
-            anchor = key
-            break
-    else:
-        anchor = None
-    if anchor in used_anchors:
-        return False, anchor
-    if anchor is not None:
-        used_anchors.add(anchor)
-    return True, anchor
+    def handle_specific(
+        self,
+        dependency_set_context: "Any",
+        key: "yaml.Node",  # noqa: ARG002
+        value: "yaml.Node",  # noqa: ARG002
+    ) -> "contextlib.AbstractContextManager[Any]":
+        return self._handle_context(
+            "handle_specific", dependency_set_context, key, value
+        )
+
+    def handle_specific_item(
+        self,
+        specific_context: "Any",
+        item: "yaml.Node",  # noqa: ARG002
+    ) -> "contextlib.AbstractContextManager[Any]":
+        return self._handle_context(
+            "handle_specific_item", specific_context, item
+        )
+
+    def handle_matrices(
+        self,
+        specific_item_context: "Any",
+        key: "yaml.Node",  # noqa: ARG002
+        value: "yaml.Node",  # noqa: ARG002
+    ) -> "contextlib.AbstractContextManager[Any]":
+        return self._handle_context(
+            "handle_matrices", specific_item_context, key, value
+        )
+
+    def handle_matrices_item(
+        self,
+        matrices_context: "Any",
+        item: "yaml.Node",  # noqa: ARG002
+    ) -> "contextlib.AbstractContextManager[Any]":
+        return self._handle_context(
+            "handle_matrices_item", matrices_context, item
+        )
+
+    def handle_matrix(
+        self,
+        matrices_item_context: "Any",
+        key: "yaml.Node",  # noqa: ARG002
+        value: "yaml.Node",  # noqa: ARG002
+    ) -> "contextlib.AbstractContextManager[Any]":
+        return self._handle_context(
+            "handle_matrix", matrices_item_context, key, value
+        )
+
+    def handle_matrix_item(
+        self,
+        matrix_context: "Any",  # noqa: ARG002
+        key: "yaml.Node",  # noqa: ARG002
+        value: "yaml.Node",  # noqa: ARG002
+    ) -> None:
+        return self._handle_no_context(
+            "handle_matrix_item", matrix_context, key, value
+        )
+
+    def handle_packages(
+        self,
+        common_or_matrices_item_context: "Any",
+        key: "yaml.Node",  # noqa: ARG002
+        value: "yaml.Node",  # noqa: ARG002
+    ) -> "contextlib.AbstractContextManager[Any]":
+        return self._handle_context(
+            "handle_packages", common_or_matrices_item_context, key, value
+        )
+
+    def handle_package(
+        self,
+        packages_context: "Any",  # noqa: ARG002
+        anchor: "Optional[str]",  # noqa: ARG002
+        item: "yaml.Node",  # noqa: ARG002
+    ) -> None:
+        return self._handle_no_context(
+            "handle_package", packages_context, anchor, item
+        )
 
 
 def traverse_package(

--- a/src/rapids_pre_commit_hooks/utils/yaml.py
+++ b/src/rapids_pre_commit_hooks/utils/yaml.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import yaml
+
+
+class AnchorPreservingLoader(yaml.SafeLoader):
+    """A SafeLoader that preserves the anchors for later reference. The anchors
+    can be found in the document_anchors member, which is a list of
+    dictionaries, one dictionary for each parsed document.
+    """
+
+    def __init__(self, stream) -> None:
+        super().__init__(stream)
+        self.document_anchors: list[dict[str, yaml.Node]] = []
+
+    def compose_document(self) -> "yaml.Node":
+        # Drop the DOCUMENT-START event.
+        self.get_event()
+
+        # Compose the root node.
+        node = self.compose_node(None, None)  # type: ignore[arg-type]
+
+        # Drop the DOCUMENT-END event.
+        self.get_event()
+
+        self.document_anchors.append(self.anchors)
+        self.anchors = {}
+        assert node is not None
+        return node
+
+
+def node_has_type(node: "yaml.Node", tag_type: str) -> bool:
+    return node.tag == f"tag:yaml.org,2002:{tag_type}"
+
+
+def check_and_mark_anchor(
+    anchors: dict[str, "yaml.Node"], used_anchors: set[str], node: "yaml.Node"
+) -> tuple[bool, str | None]:
+    for key, value in anchors.items():
+        if value == node:
+            anchor = key
+            break
+    else:
+        anchor = None
+    if anchor in used_anchors:
+        return False, anchor
+    if anchor is not None:
+        used_anchors.add(anchor)
+    return True, anchor

--- a/tests/rapids_pre_commit_hooks/test_alpha_spec.py
+++ b/tests/rapids_pre_commit_hooks/test_alpha_spec.py
@@ -15,7 +15,7 @@ from rapids_metadata.metadata import (
 )
 
 from rapids_pre_commit_hooks import alpha_spec, lint
-from rapids_pre_commit_hooks.utils import dependencies_yaml
+from rapids_pre_commit_hooks.utils.yaml import AnchorPreservingLoader
 from rapids_pre_commit_hooks_test_utils import parse_named_spans
 
 latest_version, latest_metadata = max(
@@ -233,7 +233,7 @@ def test_strip_cuda_suffix(name, stripped_name):
 def test_check_package_spec(package, anchor, content, mode, replacement):
     args = Mock(mode=mode)
     linter = lint.Linter("dependencies.yaml", content, "verify-alpha-spec")
-    loader = dependencies_yaml.AnchorPreservingLoader(content)
+    loader = AnchorPreservingLoader(content)
     try:
         composed = loader.get_single_node()
     finally:

--- a/tests/rapids_pre_commit_hooks/utils/test_dependencies_yaml.py
+++ b/tests/rapids_pre_commit_hooks/utils/test_dependencies_yaml.py
@@ -76,6 +76,10 @@ class TestChainedHandler:
         chained_handler.add_handler(manager.handler_1)
         chained_handler.add_handler(manager.handler_2)
 
+        expected_context = (
+            getattr(manager.handler_1, hook_name)().__enter__(),
+            getattr(manager.handler_2, hook_name)().__enter__(),
+        )
         expected_calls = [
             getattr(call.handler_1, hook_name)(*hook_args),
             getattr(call.handler_1, hook_name)().__enter__(
@@ -94,8 +98,8 @@ class TestChainedHandler:
         ]
         manager.reset_mock()
 
-        with getattr(chained_handler, hook_name)(*hook_args):
-            pass
+        with getattr(chained_handler, hook_name)(*hook_args) as context:
+            assert context == expected_context
 
         assert manager.mock_calls == expected_calls
 

--- a/tests/rapids_pre_commit_hooks/utils/test_dependencies_yaml.py
+++ b/tests/rapids_pre_commit_hooks/utils/test_dependencies_yaml.py
@@ -8,80 +8,128 @@ import yaml
 from rapids_pre_commit_hooks.utils import dependencies_yaml
 
 
-def test_anchor_preserving_loader():
-    loader = dependencies_yaml.AnchorPreservingLoader("- &a A\n- *a")
-    try:
-        root = loader.get_single_node()
-    finally:
-        loader.dispose()
-    assert loader.document_anchors == [{"a": root.value[0]}]
-
-
-@pytest.mark.parametrize(
-    [
-        "used_anchors_before",
-        "node_index",
-        "descend",
-        "anchor",
-        "used_anchors_after",
-    ],
-    [
-        (
-            set(),
-            0,
-            True,
-            "anchor1",
-            {"anchor1"},
-        ),
-        (
-            {"anchor1"},
-            1,
-            True,
-            "anchor2",
-            {"anchor1", "anchor2"},
-        ),
-        (
-            set(),
-            2,
-            True,
-            None,
-            set(),
-        ),
-        (
-            {"anchor1", "anchor2"},
-            0,
-            False,
-            "anchor1",
-            {"anchor1", "anchor2"},
-        ),
-        (
-            {"anchor1", "anchor2"},
-            1,
-            False,
-            "anchor2",
-            {"anchor1", "anchor2"},
-        ),
-    ],
-)
-def test_check_and_mark_anchor(
-    used_anchors_before,
-    node_index,
-    descend,
-    anchor,
-    used_anchors_after,
-):
-    NODES = [Mock() for _ in range(3)]
-    ANCHORS = {
-        "anchor1": NODES[0],
-        "anchor2": NODES[1],
-    }
-    used_anchors = set(used_anchors_before)
-    actual_descend, actual_anchor = dependencies_yaml.check_and_mark_anchor(
-        ANCHORS, used_anchors, NODES[node_index]
+class TestChainedHandler:
+    @pytest.mark.parametrize(
+        ["hook_name", "hook_args"],
+        [
+            pytest.param(
+                "handle_root",
+                (Mock(),),
+                id="handle_root",
+            ),
+            pytest.param(
+                "handle_dependencies",
+                (Mock(), Mock(), Mock()),
+                id="handle_dependencies",
+            ),
+            pytest.param(
+                "handle_dependency_set",
+                (Mock(), Mock(), Mock()),
+                id="handle_dependency_set",
+            ),
+            pytest.param(
+                "handle_common",
+                (Mock(), Mock(), Mock()),
+                id="handle_common",
+            ),
+            pytest.param(
+                "handle_common_item",
+                (Mock(), Mock()),
+                id="handle_common_item",
+            ),
+            pytest.param(
+                "handle_specific",
+                (Mock(), Mock(), Mock()),
+                id="handle_specific",
+            ),
+            pytest.param(
+                "handle_specific_item",
+                (Mock(), Mock()),
+                id="handle_specific_item",
+            ),
+            pytest.param(
+                "handle_matrices",
+                (Mock(), Mock(), Mock()),
+                id="handle_matrices",
+            ),
+            pytest.param(
+                "handle_matrices_item",
+                (Mock(), Mock()),
+                id="handle_matrices_item",
+            ),
+            pytest.param(
+                "handle_matrix",
+                (Mock(), Mock(), Mock()),
+                id="handle_matrix",
+            ),
+            pytest.param(
+                "handle_packages",
+                (Mock(), Mock(), Mock()),
+                id="handle_packages",
+            ),
+        ],
     )
-    assert actual_descend == descend
-    assert actual_anchor == anchor
-    assert used_anchors == used_anchors_after
+    def test_context(self, hook_name, hook_args):
+        manager = MagicMock()
+
+        chained_handler = dependencies_yaml.ChainedHandler()
+        chained_handler.add_handler(manager.handler_1)
+        chained_handler.add_handler(manager.handler_2)
+
+        expected_calls = [
+            getattr(call.handler_1, hook_name)(*hook_args),
+            getattr(call.handler_1, hook_name)().__enter__(
+                getattr(manager.handler_1, hook_name)()
+            ),
+            getattr(call.handler_2, hook_name)(*hook_args),
+            getattr(call.handler_2, hook_name)().__enter__(
+                getattr(manager.handler_2, hook_name)()
+            ),
+            getattr(call.handler_2, hook_name)().__exit__(
+                getattr(manager.handler_2, hook_name)(), None, None, None
+            ),
+            getattr(call.handler_1, hook_name)().__exit__(
+                getattr(manager.handler_1, hook_name)(), None, None, None
+            ),
+        ]
+        manager.reset_mock()
+
+        with getattr(chained_handler, hook_name)(*hook_args):
+            pass
+
+        assert manager.mock_calls == expected_calls
+
+    @pytest.mark.parametrize(
+        ["hook_name", "hook_args"],
+        [
+            pytest.param(
+                "handle_matrix_item",
+                (Mock(), Mock(), Mock()),
+                id="handle_matrix_item",
+            ),
+            pytest.param(
+                "handle_package",
+                (Mock(), "anchor", Mock()),
+                id="handle_package",
+            ),
+        ],
+    )
+    def test_no_context(self, hook_name, hook_args):
+        manager = MagicMock()
+
+        chained_handler = dependencies_yaml.ChainedHandler()
+        chained_handler.add_handler(manager.handler_1)
+        chained_handler.add_handler(manager.handler_2)
+
+        expected_calls = [
+            getattr(call.handler_1, hook_name)(*hook_args),
+            getattr(call.handler_2, hook_name)(*hook_args),
+        ]
+        manager.reset_mock()
+
+        getattr(chained_handler, hook_name)(*hook_args)
+
+        assert manager.mock_calls == expected_calls
 
 
 def test_traverse_package():

--- a/tests/rapids_pre_commit_hooks/utils/test_yaml.py
+++ b/tests/rapids_pre_commit_hooks/utils/test_yaml.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+import pytest
+
+from rapids_pre_commit_hooks.utils.yaml import (
+    AnchorPreservingLoader,
+    check_and_mark_anchor,
+)
+
+
+def test_anchor_preserving_loader():
+    loader = AnchorPreservingLoader("- &a A\n- *a")
+    try:
+        root = loader.get_single_node()
+    finally:
+        loader.dispose()
+    assert loader.document_anchors == [{"a": root.value[0]}]
+
+
+@pytest.mark.parametrize(
+    [
+        "used_anchors_before",
+        "node_index",
+        "descend",
+        "anchor",
+        "used_anchors_after",
+    ],
+    [
+        (
+            set(),
+            0,
+            True,
+            "anchor1",
+            {"anchor1"},
+        ),
+        (
+            {"anchor1"},
+            1,
+            True,
+            "anchor2",
+            {"anchor1", "anchor2"},
+        ),
+        (
+            set(),
+            2,
+            True,
+            None,
+            set(),
+        ),
+        (
+            {"anchor1", "anchor2"},
+            0,
+            False,
+            "anchor1",
+            {"anchor1", "anchor2"},
+        ),
+        (
+            {"anchor1", "anchor2"},
+            1,
+            False,
+            "anchor2",
+            {"anchor1", "anchor2"},
+        ),
+    ],
+)
+def test_check_and_mark_anchor(
+    used_anchors_before,
+    node_index,
+    descend,
+    anchor,
+    used_anchors_after,
+):
+    NODES = [Mock() for _ in range(3)]
+    ANCHORS = {
+        "anchor1": NODES[0],
+        "anchor2": NODES[1],
+    }
+    used_anchors = set(used_anchors_before)
+    actual_descend, actual_anchor = check_and_mark_anchor(
+        ANCHORS, used_anchors, NODES[node_index]
+    )
+    assert actual_descend == descend
+    assert actual_anchor == anchor
+    assert used_anchors == used_anchors_after

--- a/tests/test_testing_utils.py
+++ b/tests/test_testing_utils.py
@@ -5,7 +5,12 @@ import contextlib
 
 import pytest
 
-from rapids_pre_commit_hooks_test_utils import ParseError, parse_named_spans
+from rapids_pre_commit_hooks.utils.yaml import AnchorPreservingLoader
+from rapids_pre_commit_hooks_test_utils import (
+    ParseError,
+    find_yaml_node_for_span,
+    parse_named_spans,
+)
 
 
 @pytest.mark.parametrize(
@@ -674,3 +679,125 @@ def test_parse_named_spans(
         content, spans = parse_named_spans(content, root_type)
         assert content == expected_content
         assert spans == expected_spans
+
+
+@pytest.mark.parametrize(
+    ["content", "node_lambda"],
+    [
+        pytest.param(
+            """\
+            + root_node
+            : ~~~~~~~~~node
+            """,
+            lambda root: root,
+            id="basic-string",
+        ),
+        pytest.param(
+            """\
+            + 12345
+            : ~~~~~node
+            """,
+            lambda root: root,
+            id="basic-number",
+        ),
+        pytest.param(
+            """\
+            + null
+            : ~~~~node
+            """,
+            lambda root: root,
+            id="basic-null",
+        ),
+        pytest.param(
+            """\
+            + key1: value1
+            : >node
+            + key2: value2
+            :              !node
+            """,
+            lambda root: root,
+            id="map-root",
+        ),
+        pytest.param(
+            """\
+            + key1: value1
+            : ~~~~node
+            + key2: value2
+            """,
+            lambda root: root.value[0][0],
+            id="map-key-1",
+        ),
+        pytest.param(
+            """\
+            + key1: value1
+            :       ~~~~~~node
+            + key2: value2
+            """,
+            lambda root: root.value[0][1],
+            id="map-value-1",
+        ),
+        pytest.param(
+            """\
+            + key1: value1
+            + key2: value2
+            : ~~~~node
+            """,
+            lambda root: root.value[1][0],
+            id="map-key-2",
+        ),
+        pytest.param(
+            """\
+            + key1: value1
+            + key2: value2
+            :       ~~~~~~node
+            """,
+            lambda root: root.value[1][1],
+            id="map-value-2",
+        ),
+        pytest.param(
+            """\
+            + - item1
+            : >node
+            + - item2
+            :         !node
+            """,
+            lambda root: root,
+            id="seq-root",
+        ),
+        pytest.param(
+            """\
+            + - item1
+            :   ~~~~~node
+            + - item2
+            """,
+            lambda root: root.value[0],
+            id="seq-item-1",
+        ),
+        pytest.param(
+            """\
+            + - item1
+            + - item2
+            :   ~~~~~node
+            """,
+            lambda root: root.value[1],
+            id="seq-item-2",
+        ),
+        pytest.param(
+            """\
+            + root_node
+            :  ~~~node
+            """,
+            lambda _root: None,
+            id="no-node",
+        ),
+    ],
+)
+def test_find_yaml_node_for_span(content, node_lambda):
+    content, spans = parse_named_spans(content)
+    loader = AnchorPreservingLoader(content)
+    try:
+        root = loader.get_single_node()
+    finally:
+        loader.dispose()
+
+    assert find_yaml_node_for_span(root, spans["node"]) == node_lambda(root)

--- a/tests/utils/rapids_pre_commit_hooks_test_utils.py
+++ b/tests/utils/rapids_pre_commit_hooks_test_utils.py
@@ -6,10 +6,13 @@ import re
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
+from rapids_pre_commit_hooks.utils.yaml import node_has_type
 from rapids_pre_commit_hooks.lint import Lines
 
 if TYPE_CHECKING:
-    from typing import TypeGuard
+    from typing import Optional, TypeGuard
+
+    import yaml
 
     from rapids_pre_commit_hooks.lint import Span
 
@@ -256,3 +259,21 @@ def parse_named_spans(
     if root_type is not None and not isinstance(postprocessed, root_type):
         raise ParseError
     return content, postprocessed
+
+
+def find_yaml_node_for_span(
+    node: "yaml.Node", span: "Span"
+) -> "Optional[yaml.Node]":
+    if (node.start_mark.index, node.end_mark.index) == span:
+        return node
+    if node_has_type(node, "map"):
+        for key, value in node.value:
+            if found := find_yaml_node_for_span(key, span):
+                return found
+            if found := find_yaml_node_for_span(value, span):
+                return found
+    if node_has_type(node, "seq"):
+        for item in node.value:
+            if found := find_yaml_node_for_span(item, span):
+                return found
+    return None


### PR DESCRIPTION
* Split some non-`dependencies.yaml`-specific YAML code into a separate module
* Add test function to get YAML node from span
* Add chained `dependencies.yaml` handler

Issue: https://github.com/rapidsai/pre-commit-hooks/issues/132